### PR TITLE
fix(attendance,biometrics,org): multi-status filter fix, partial sync detection & Section-Department M2M migration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,5 @@ Thumbs.db
 .prettierrc
 oldStructure/
 .kilo/
+
+data/

--- a/backend/prisma/migrations/20260629022222_section_department_many_to_many/migration.sql
+++ b/backend/prisma/migrations/20260629022222_section_department_many_to_many/migration.sql
@@ -1,0 +1,40 @@
+-- CreateTable
+CREATE TABLE "SectionDepartment" (
+    "sectionId" INTEGER NOT NULL,
+    "departmentId" INTEGER NOT NULL,
+    "assignedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "SectionDepartment_pkey" PRIMARY KEY ("sectionId","departmentId")
+);
+
+-- Copy existing relationships from Section to SectionDepartment join table
+INSERT INTO "SectionDepartment" ("sectionId", "departmentId")
+SELECT "id", "departmentId" FROM "Section"
+WHERE "departmentId" IS NOT NULL;
+
+-- DropForeignKey
+ALTER TABLE "Section" DROP CONSTRAINT "Section_departmentId_fkey";
+
+-- DropIndex
+DROP INDEX "Section_name_departmentId_key";
+
+-- DropIndex
+DROP INDEX "Section_departmentId_idx";
+
+-- AlterTable
+ALTER TABLE "Section" DROP COLUMN "departmentId";
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Section_name_key" ON "Section"("name");
+
+-- AddForeignKey
+ALTER TABLE "SectionDepartment" ADD CONSTRAINT "SectionDepartment_sectionId_fkey" FOREIGN KEY ("sectionId") REFERENCES "Section"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "SectionDepartment" ADD CONSTRAINT "SectionDepartment_departmentId_fkey" FOREIGN KEY ("departmentId") REFERENCES "Department"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- CreateIndex
+CREATE INDEX "SectionDepartment_sectionId_idx" ON "SectionDepartment"("sectionId");
+
+-- CreateIndex
+CREATE INDEX "SectionDepartment_departmentId_idx" ON "SectionDepartment"("departmentId");

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -111,20 +111,28 @@ model Department {
   updatedAt         DateTime
   Employee          Employee[]
   ManagerDepartment ManagerDepartment[]
-  Section           Section[]
+  sections          SectionDepartment[]
 }
 
 model Section {
-  id           Int        @id @default(autoincrement())
-  name         String
-  departmentId Int
-  createdAt    DateTime   @default(now())
-  updatedAt    DateTime   @updatedAt
-
-  department   Department @relation(fields: [departmentId], references: [id], onDelete: Cascade)
+  id           Int                 @id @default(autoincrement())
+  name         String              @unique
+  createdAt    DateTime            @default(now())
+  updatedAt    DateTime            @updatedAt
   Employee     Employee[]
+  departments  SectionDepartment[]
+}
 
-  @@unique([name, departmentId])
+model SectionDepartment {
+  sectionId    Int
+  departmentId Int
+  assignedAt   DateTime   @default(now())
+
+  section      Section    @relation(fields: [sectionId], references: [id], onDelete: Cascade)
+  department   Department @relation(fields: [departmentId], references: [id], onDelete: Cascade)
+
+  @@id([sectionId, departmentId])
+  @@index([sectionId])
   @@index([departmentId])
 }
 

--- a/backend/prisma/seed.ts
+++ b/backend/prisma/seed.ts
@@ -75,18 +75,28 @@ async function main() {
         })
         if (dept) {
             for (const sectionName of seed.sections) {
-                await prisma.section.upsert({
-                    where: {
-                        name_departmentId: {
+                let section = await prisma.section.findUnique({
+                    where: { name: sectionName }
+                })
+                if (!section) {
+                    section = await prisma.section.create({
+                        data: {
                             name: sectionName,
+                            updatedAt: new Date()
+                        }
+                    })
+                }
+                await prisma.sectionDepartment.upsert({
+                    where: {
+                        sectionId_departmentId: {
+                            sectionId: section.id,
                             departmentId: dept.id
                         }
                     },
                     update: {},
                     create: {
-                        name: sectionName,
-                        departmentId: dept.id,
-                        updatedAt: new Date()
+                        sectionId: section.id,
+                        departmentId: dept.id
                     }
                 })
                 console.log(`🧩 Section: ${sectionName} in ${seed.departmentName}`)

--- a/backend/src/modules/attendance/attendance-processor.ts
+++ b/backend/src/modules/attendance/attendance-processor.ts
@@ -534,7 +534,93 @@ export async function recalculateAndPersistAttendanceMetrics(
 
 export const processAttendanceLogs = async (): Promise<ProcessResult> => {
     try {
-        const cutoff = new Date(Date.now() - 2 * 24 * 60 * 60 * 1000);
+        const cutoff = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
+
+        // Pre-processing step: Retrieve all currently unprocessed logs to identify which employees
+        // and dates require chronological re-processing.
+        const unprocessedLogs = await prisma.attendanceLog.findMany({
+            where: { 
+                timestamp: { gte: cutoff },
+                processedAt: null
+            },
+            select: { employeeId: true, timestamp: true }
+        });
+
+        if (unprocessedLogs.length > 0) {
+            const reprocessKeys = new Set<string>();
+            const reprocessPairs: { employeeId: number; date: Date }[] = [];
+
+            unprocessedLogs.forEach(log => {
+                const d1 = toPHTDate(log.timestamp);
+                const d2 = new Date(d1.getTime() - 24 * 60 * 60 * 1000);
+
+                [d1, d2].forEach(d => {
+                    const key = `${log.employeeId}_${d.getTime()}`;
+                    if (!reprocessKeys.has(key)) {
+                        reprocessKeys.add(key);
+                        reprocessPairs.push({ employeeId: log.employeeId, date: d });
+                    }
+                });
+            });
+
+            for (const { employeeId, date } of reprocessPairs) {
+                const existingRecords = await prisma.attendance.findMany({
+                    where: { employeeId, date }
+                });
+
+                let hasManualOrAdjustments = false;
+                for (const rec of existingRecords) {
+                    if (rec.checkoutSource === 'manual') {
+                        hasManualOrAdjustments = true;
+                        break;
+                    }
+                    const adjustmentsCount = await prisma.attendanceAdjustment.count({
+                        where: {
+                            attendanceId: rec.id,
+                            status: { in: ['pending', 'approved'] }
+                        }
+                    });
+                    if (adjustmentsCount > 0) {
+                        hasManualOrAdjustments = true;
+                        break;
+                    }
+                }
+
+                if (!hasManualOrAdjustments) {
+                    const startRange = date;
+                    const endRange = new Date(date.getTime() + 32 * 60 * 60 * 1000);
+
+                    // Reset processedAt = null for all raw logs of this employee in this target date range
+                    await prisma.attendanceLog.updateMany({
+                        where: {
+                            employeeId,
+                            timestamp: { gte: startRange, lt: endRange }
+                        },
+                        data: { processedAt: null }
+                    });
+
+                    // Clear the actual times on any approved OvertimeRequest for this employee and date
+                    await prisma.overtimeRequest.updateMany({
+                        where: {
+                            employeeId,
+                            date,
+                            status: 'APPROVED'
+                        },
+                        data: {
+                            actualStartTime: null,
+                            actualEndTime: null
+                        }
+                    });
+
+                    // Delete the pure device-based Attendance records
+                    if (existingRecords.length > 0) {
+                        await prisma.attendance.deleteMany({
+                            where: { employeeId, date }
+                        });
+                    }
+                }
+            }
+        }
 
         const logs = await prisma.attendanceLog.findMany({
             where: { 

--- a/backend/src/modules/devices/zk/zk-fingerprint.service.ts
+++ b/backend/src/modules/devices/zk/zk-fingerprint.service.ts
@@ -648,6 +648,13 @@ export const syncEmployeeFingerprints = async (
             if (missingFingers.length === 0) {
                 results.push({ deviceId: targetDevice.id, deviceName: targetDevice.name, status: 'skipped', pushed: 0, failed: 0 });
                 console.log(`[SyncFingers] "${targetDevice.name}": all ${allFingerIndices.length} finger(s) already enrolled on device — skipping.`);
+                
+                // Ensure overall device enrollment record exists in DB
+                await prisma.employeeDeviceEnrollment.upsert({
+                    where: { employeeId_deviceId: { employeeId, deviceId: targetDevice.id } },
+                    update: {},
+                    create: { employeeId, deviceId: targetDevice.id },
+                });
                 continue;
             }
 
@@ -780,10 +787,17 @@ export const syncEmployeeFingerprints = async (
 
             if (pushed > 0) {
                 await tgtZk.refreshData();
+            }
+
+            if (slotErrors.length === 0) {
                 await prisma.employeeDeviceEnrollment.upsert({
                     where: { employeeId_deviceId: { employeeId, deviceId: targetDevice.id } },
                     update: { enrolledAt: new Date() },
                     create: { employeeId, deviceId: targetDevice.id },
+                });
+            } else {
+                await prisma.employeeDeviceEnrollment.deleteMany({
+                    where: { employeeId, deviceId: targetDevice.id },
                 });
             }
 
@@ -957,11 +971,3 @@ async function extractAndDistributeTemplate(deviceId: number, employeeId: number
         );	
     }	
 }	
-	
-// ─────────────────────────────────────────────────────────────────────────────	
-// DEBUG & FORCED SYNC	
-// ─────────────────────────────────────────────────────────────────────────────	
-// RFID BADGE CARD ENROLLMENT	
-// Writes a card number into the user record on ALL active devices, then
-
-

--- a/backend/src/modules/employees/employee-biometric.controller.ts
+++ b/backend/src/modules/employees/employee-biometric.controller.ts
@@ -320,12 +320,28 @@ export const getEmployeeFingerprintStatus = async (req: Request, res: Response) 
             },
         });
 
+        const totalEmployeeFingers = enrollments.map(e => e.fingerIndex);
+        const uniqueFingers = new Set(totalEmployeeFingers);
+        const totalEnrolled = uniqueFingers.size;
+
         const devicesResult = activeDevices.map(device => {
             const enroll = deviceEnrollments.find(e => e.deviceId === device.id);
+            const deviceFingerCount = enrollments.filter(e => e.deviceId === device.id).length;
+            
+            let syncStatus: 'synced' | 'partial' | 'not_synced' = 'not_synced';
+            if (totalEnrolled > 0) {
+                if (deviceFingerCount === totalEnrolled) {
+                    syncStatus = 'synced';
+                } else if (deviceFingerCount > 0) {
+                    syncStatus = 'partial';
+                }
+            }
+
             return {
                 deviceId: device.id,
                 deviceName: device.name,
-                enrolled: !!enroll,
+                enrolled: totalEnrolled > 0 && deviceFingerCount === totalEnrolled,
+                syncStatus,
                 enrolledAt: enroll ? enroll.enrolledAt.toISOString() : undefined,
                 isActive: device.isActive,
                 syncEnabled: device.syncEnabled,
@@ -415,7 +431,7 @@ export const getEmployeeFingerprintStatus = async (req: Request, res: Response) 
             });
         }
 
-        const totalEnrolled = fingerMap.size;
+
 
         return res.status(200).json({
             success: true,

--- a/backend/src/modules/employees/employee-export.controller.ts
+++ b/backend/src/modules/employees/employee-export.controller.ts
@@ -768,7 +768,13 @@ export const bulkCreateEmployees = async (req: Request, res: Response) => {
                                 ? (await prisma.section.findFirst({
                                     where: {
                                         name: { equals: emp.section, mode: 'insensitive' },
-                                        department: { name: { equals: emp.department, mode: 'insensitive' } }
+                                        departments: {
+                                            some: {
+                                                department: {
+                                                    name: { equals: emp.department, mode: 'insensitive' }
+                                                }
+                                            }
+                                        }
                                     },
                                     select: { id: true }
                                 }))?.id ?? null

--- a/backend/src/modules/organization/department.controller.ts
+++ b/backend/src/modules/organization/department.controller.ts
@@ -10,14 +10,28 @@ export const getAllDepartments = async (req: Request, res: Response) => {
                 name: 'asc'
             },
             include: {
-                Section: {
-                    select: { id: true, name: true }
+                sections: {
+                    include: {
+                        section: {
+                            select: { id: true, name: true }
+                        }
+                    }
                 }
             }
         });
+
+        // Map Sections to match the original shape (Section[]) for backwards compatibility
+        const mappedDepartments = departments.map(d => ({
+            id: d.id,
+            name: d.name,
+            createdAt: d.createdAt,
+            updatedAt: d.updatedAt,
+            Section: d.sections.map(s => s.section)
+        }));
+
         res.json({
             success: true,
-            departments
+            departments: mappedDepartments
         });
     } catch (error) {
         console.error('Error fetching departments:', error);
@@ -40,24 +54,35 @@ export const createDepartment = async (req: Request, res: Response) => {
         if (existing) {
             return res.status(400).json({ success: false, message: 'Department already exists' });
         }
+
         const department = await prisma.department.create({
-            data: { name: trimmedName, updatedAt: new Date() },
-            include: { Section: { select: { id: true, name: true } } }
+            data: {
+                name: trimmedName,
+                updatedAt: new Date(),
+                sections: {
+                    create: Array.isArray(sectionIds) ? sectionIds.map((sid: number) => ({
+                        sectionId: sid
+                    })) : []
+                }
+            },
+            include: {
+                sections: {
+                    include: {
+                        section: {
+                            select: { id: true, name: true }
+                        }
+                    }
+                }
+            }
         });
 
-        // Reassign selected sections to this new department
-        if (Array.isArray(sectionIds) && sectionIds.length > 0) {
-            await prisma.section.updateMany({
-                where: { id: { in: sectionIds } },
-                data: { departmentId: department.id, updatedAt: new Date() }
-            });
-        }
-
-        // Re-fetch with updated sections
-        const updatedDepartment = await prisma.department.findUnique({
-            where: { id: department.id },
-            include: { Section: { select: { id: true, name: true } } }
-        });
+        const mappedDepartment = {
+            id: department.id,
+            name: department.name,
+            createdAt: department.createdAt,
+            updatedAt: department.updatedAt,
+            Section: department.sections.map(s => s.section)
+        };
 
         void auditCreate({
             entityType: 'Department',
@@ -70,7 +95,7 @@ export const createDepartment = async (req: Request, res: Response) => {
             'Name': department.name
         });
 
-        res.status(201).json({ success: true, department: updatedDepartment });
+        res.status(201).json({ success: true, department: mappedDepartment });
     } catch (error) {
         console.error('Error creating department:', error);
         res.status(500).json({ success: false, message: 'Failed to create department' });
@@ -95,7 +120,7 @@ export const renameDepartment = async (req: Request, res: Response) => {
         }
         const target = await prisma.department.findUnique({
             where: { id },
-            include: { Section: { select: { id: true } } }
+            include: { sections: { select: { sectionId: true } } }
         });
         if (!target) {
             return res.status(404).json({ success: false, message: 'Department not found' });
@@ -103,33 +128,42 @@ export const renameDepartment = async (req: Request, res: Response) => {
 
         // Handle section assignments if provided
         if (Array.isArray(sectionIds)) {
-            const currentSectionIds = target.Section.map(s => s.id);
+            const currentSectionIds = target.sections.map(s => s.sectionId);
             const toAdd = sectionIds.filter((sid: number) => !currentSectionIds.includes(sid));
             const toRemove = currentSectionIds.filter(sid => !sectionIds.includes(sid));
 
-            // Check for active employees in sections being removed
+            // Check for active employees in sections being removed from this specific department
             if (toRemove.length > 0) {
                 const activeInRemoved = await prisma.employee.count({
                     where: {
                         sectionId: { in: toRemove },
+                        departmentId: id,
                         employmentStatus: 'ACTIVE'
                     }
                 });
                 if (activeInRemoved > 0) {
                     return res.status(400).json({
                         success: false,
-                        message: `⚠️ Cannot remove section(s) with ${activeInRemoved} active employee(s). Please reassign employees first.`
+                        message: `⚠️ Cannot remove section(s) with ${activeInRemoved} active employee(s) in this department. Please reassign employees first.`
                     });
                 }
-                // Delete empty sections being removed
-                await prisma.section.deleteMany({ where: { id: { in: toRemove } } });
+                
+                // Delete relationships from the join table
+                await prisma.sectionDepartment.deleteMany({
+                    where: {
+                        departmentId: id,
+                        sectionId: { in: toRemove }
+                    }
+                });
             }
 
-            // Reassign sections being added to this department
+            // Create relationships in the join table
             if (toAdd.length > 0) {
-                await prisma.section.updateMany({
-                    where: { id: { in: toAdd } },
-                    data: { departmentId: id, updatedAt: new Date() }
+                await prisma.sectionDepartment.createMany({
+                    data: toAdd.map((sid: number) => ({
+                        departmentId: id,
+                        sectionId: sid
+                    }))
                 });
             }
         }
@@ -137,8 +171,24 @@ export const renameDepartment = async (req: Request, res: Response) => {
         const department = await prisma.department.update({
             where: { id },
             data: { name: trimmedName, updatedAt: new Date() },
-            include: { Section: { select: { id: true, name: true } } }
+            include: {
+                sections: {
+                    include: {
+                        section: {
+                            select: { id: true, name: true }
+                        }
+                    }
+                }
+            }
         });
+
+        const mappedDepartment = {
+            id: department.id,
+            name: department.name,
+            createdAt: department.createdAt,
+            updatedAt: department.updatedAt,
+            Section: department.sections.map(s => s.section)
+        };
 
         const changes = [];
         if (target.name !== trimmedName) {
@@ -154,7 +204,7 @@ export const renameDepartment = async (req: Request, res: Response) => {
             correlationId: req.correlationId
         }, changes);
 
-        res.json({ success: true, department });
+        res.json({ success: true, department: mappedDepartment });
     } catch (error) {
         console.error('Error renaming department:', error);
         res.status(500).json({ success: false, message: 'Failed to rename department' });

--- a/backend/src/modules/organization/organization.types.ts
+++ b/backend/src/modules/organization/organization.types.ts
@@ -12,7 +12,6 @@ export type UpdateBranchRequest = Partial<CreateBranchRequest>;
 
 export interface CreateSectionRequest {
     name: string;
-    departmentId: number;
 }
 
 export type UpdateSectionRequest = Partial<Pick<CreateSectionRequest, 'name'>>;

--- a/backend/src/modules/organization/section.controller.ts
+++ b/backend/src/modules/organization/section.controller.ts
@@ -11,16 +11,25 @@ export const getAllSections = async (req: Request, res: Response) => {
         if (departmentIdQuery) {
             const deptId = parseInt(String(departmentIdQuery), 10);
             if (!isNaN(deptId)) {
-                whereClause.departmentId = deptId;
+                whereClause.departments = {
+                    some: {
+                        departmentId: deptId
+                    }
+                };
             }
         }
 
         const sections = await prisma.section.findMany({
             where: whereClause,
             include: {
-                department: {
-                    select: {
-                        name: true
+                departments: {
+                    include: {
+                        department: {
+                            select: {
+                                id: true,
+                                name: true
+                            }
+                        }
                     }
                 }
             },
@@ -45,47 +54,35 @@ export const getAllSections = async (req: Request, res: Response) => {
 // POST /api/sections
 export const createSection = async (req: Request, res: Response) => {
     try {
-        const { name, departmentId } = req.body;
+        const { name } = req.body;
         if (!name || !name.trim()) {
             return res.status(400).json({ success: false, message: 'Section name is required' });
-        }
-        if (!departmentId) {
-            return res.status(400).json({ success: false, message: 'Department ID is required' });
-        }
-
-        const deptId = parseInt(String(departmentId), 10);
-        if (isNaN(deptId)) {
-            return res.status(400).json({ success: false, message: 'Invalid department ID' });
-        }
-
-        const departmentExists = await prisma.department.findUnique({
-            where: { id: deptId }
-        });
-        if (!departmentExists) {
-            return res.status(404).json({ success: false, message: 'Department not found' });
         }
 
         const trimmedName = name.trim().toUpperCase();
         const existing = await prisma.section.findFirst({
             where: {
-                name: trimmedName,
-                departmentId: deptId
+                name: trimmedName
             }
         });
         if (existing) {
-            return res.status(400).json({ success: false, message: 'Section already exists in this department' });
+            return res.status(400).json({ success: false, message: 'Section already exists' });
         }
 
         const section = await prisma.section.create({
             data: {
                 name: trimmedName,
-                departmentId: deptId,
                 updatedAt: new Date()
             },
             include: {
-                department: {
-                    select: {
-                        name: true
+                departments: {
+                    include: {
+                        department: {
+                            select: {
+                                id: true,
+                                name: true
+                            }
+                        }
                     }
                 }
             }
@@ -96,11 +93,10 @@ export const createSection = async (req: Request, res: Response) => {
             entityId: section.id,
             performedBy: req.user?.employeeId,
             source: 'admin-panel',
-            details: `Created new section "${section.name}" in department "${section.department.name}"`,
+            details: `Created new section "${section.name}"`,
             correlationId: req.correlationId
         }, {
-            'Name': section.name,
-            'Department': section.department.name
+            'Name': section.name
         });
 
         res.status(201).json({ success: true, section });
@@ -123,14 +119,7 @@ export const renameSection = async (req: Request, res: Response) => {
         }
 
         const target = await prisma.section.findUnique({
-            where: { id },
-            include: {
-                department: {
-                    select: {
-                        name: true
-                    }
-                }
-            }
+            where: { id }
         });
         if (!target) {
             return res.status(404).json({ success: false, message: 'Section not found' });
@@ -139,21 +128,25 @@ export const renameSection = async (req: Request, res: Response) => {
         const trimmedName = name.trim().toUpperCase();
         const existing = await prisma.section.findFirst({
             where: {
-                name: trimmedName,
-                departmentId: target.departmentId
+                name: trimmedName
             }
         });
         if (existing && existing.id !== id) {
-            return res.status(409).json({ success: false, message: 'Section name already exists in this department' });
+            return res.status(409).json({ success: false, message: 'Section name already exists' });
         }
 
         const section = await prisma.section.update({
             where: { id },
             data: { name: trimmedName, updatedAt: new Date() },
             include: {
-                department: {
-                    select: {
-                        name: true
+                departments: {
+                    include: {
+                        department: {
+                            select: {
+                                id: true,
+                                name: true
+                            }
+                        }
                     }
                 }
             }
@@ -169,7 +162,7 @@ export const renameSection = async (req: Request, res: Response) => {
             entityId: section.id,
             performedBy: req.user?.employeeId,
             source: 'admin-panel',
-            details: `Renamed section to "${section.name}" in department "${section.department.name}"`,
+            details: `Renamed section to "${section.name}"`,
             correlationId: req.correlationId
         }, changes);
 
@@ -190,9 +183,13 @@ export const deleteSection = async (req: Request, res: Response) => {
         const existing = await prisma.section.findUnique({
             where: { id },
             include: {
-                department: {
-                    select: {
-                        name: true
+                departments: {
+                    include: {
+                        department: {
+                            select: {
+                                name: true
+                            }
+                        }
                     }
                 }
             }
@@ -217,17 +214,19 @@ export const deleteSection = async (req: Request, res: Response) => {
 
         await prisma.section.delete({ where: { id } });
 
+        const deptNames = existing.departments.map(d => d.department.name).join(', ') || 'None';
+
         void auditDelete({
             entityType: 'Section',
             entityId: id,
             performedBy: req.user?.employeeId,
             source: 'admin-panel',
             level: 'WARN',
-            details: `Deleted section "${existing.name}" from department "${existing.department.name}"`,
+            details: `Deleted section "${existing.name}" from department(s) "${deptNames}"`,
             correlationId: req.correlationId
         }, {
             'Name': existing.name,
-            'Department': existing.department.name
+            'Departments': deptNames
         });
 
         res.json({ success: true, message: `Section "${existing.name}" deleted` });

--- a/backend/src/scripts/debug/test-attendance-comprehensive.ts
+++ b/backend/src/scripts/debug/test-attendance-comprehensive.ts
@@ -622,6 +622,78 @@ async function runAll() {
     }
 
     // ─────────────────────────────────────────────────────────────────────────
+    // TEST 13: Out-of-Order Log Sync (Device Offline Scenario)
+    // ─────────────────────────────────────────────────────────────────────────
+    section('TEST 13: Out-of-Order Log Sync (Device Offline Scenario)');
+    divider();
+    {
+        const emp = await createTestEmployee('T13');
+        await assignShifts(emp.id, [{ shiftId: SHIFT_DAY.id, sortOrder: 1 }]);
+        await cleanEmployee(emp.id, [DATE_ONLY]);
+
+        info(`--- Sub-test A: Punch out occurs after shift end (Post-Shift Guard) ---`);
+        info(`Step 1: Punch OUT at 17:05 (Device B - online)`);
+        await prisma.attendanceLog.create({
+            data: { employeeId: emp.id, timestamp: phtTime(DATE_ONLY, '17:05'), status: 1 }
+        });
+        await processAttendanceLogs();
+
+        let records = await getAtt(emp.id, DATE_ONLY);
+        records.length === 0 ? pass('No record created initially (skipped by post-shift guard)') : fail('No record created initially', `got ${records.length}`);
+
+        info(`Step 2: Delayed Punch IN at 08:00 arrives (Device A - reconnected)`);
+        await prisma.attendanceLog.create({
+            data: { employeeId: emp.id, timestamp: phtTime(DATE_ONLY, '08:00'), status: 0 }
+        });
+        await processAttendanceLogs();
+
+        records = await getAtt(emp.id, DATE_ONLY);
+        records.length === 1 ? pass('Exactly 1 record created after reconnection') : fail('Exactly 1 record', `got ${records.length}`);
+        
+        let att = records[0];
+        if (att) {
+            att.checkInTime.getUTCHours() === phtTime(DATE_ONLY, '08:00').getUTCHours() ? pass('Check-in correctly reconciled to 08:00 AM') : fail('Check-in reconciled to 08:00 AM', `got ${att.checkInTime.toISOString()}`);
+            att.checkOutTime?.getUTCHours() === phtTime(DATE_ONLY, '17:05').getUTCHours() ? pass('Check-out correctly paired to 17:05 PM') : fail('Check-out paired to 17:05 PM', `got ${att.checkOutTime?.toISOString()}`);
+            att.lateMinutes === 0 ? pass('Late minutes is 0') : fail('Late minutes is 0', `got ${att.lateMinutes}`);
+        }
+
+        // Clean up for sub-test B
+        await cleanEmployee(emp.id, [DATE_ONLY]);
+
+        info(`--- Sub-test B: Punch out occurs before shift end (Treated as Late Check-In) ---`);
+        info(`Step 1: Punch OUT at 16:55 (Device B - online)`);
+        await prisma.attendanceLog.create({
+            data: { employeeId: emp.id, timestamp: phtTime(DATE_ONLY, '16:55'), status: 1 }
+        });
+        await processAttendanceLogs();
+
+        records = await getAtt(emp.id, DATE_ONLY);
+        records.length === 1 ? pass('Record created for check-out punch') : fail('Record created', `got ${records.length}`);
+        att = records[0];
+        if (att) {
+            att.checkInTime.getUTCHours() === phtTime(DATE_ONLY, '16:55').getUTCHours() ? pass('Initially treated as late Check-In at 16:55') : fail('Treated as late Check-In', `got ${att.checkInTime.toISOString()}`);
+            att.checkOutTime === null ? pass('Check-out is initially null') : fail('Check-out is null', `got ${att.checkOutTime}`);
+        }
+
+        info(`Step 2: Delayed Punch IN at 08:00 arrives (Device A - reconnected)`);
+        await prisma.attendanceLog.create({
+            data: { employeeId: emp.id, timestamp: phtTime(DATE_ONLY, '08:00'), status: 0 }
+        });
+        await processAttendanceLogs();
+
+        records = await getAtt(emp.id, DATE_ONLY);
+        records.length === 1 ? pass('Still exactly 1 record after reconnection') : fail('Exactly 1 record', `got ${records.length}`);
+        att = records[0];
+        if (att) {
+            att.checkInTime.getUTCHours() === phtTime(DATE_ONLY, '08:00').getUTCHours() ? pass('Check-in corrected to 08:00 AM') : fail('Check-in corrected', `got ${att.checkInTime.toISOString()}`);
+            att.checkOutTime?.getUTCHours() === phtTime(DATE_ONLY, '16:55').getUTCHours() ? pass('Check-out corrected to 16:55 PM') : fail('Check-out corrected', `got ${att.checkOutTime?.toISOString()}`);
+            att.lateMinutes === 0 ? pass('Late minutes is corrected to 0') : fail('Late minutes corrected', `got ${att.lateMinutes}`);
+        }
+
+        await destroyEmployee(emp.id);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
     // FINAL SUMMARY
     // ─────────────────────────────────────────────────────────────────────────
     console.log(`\n${C.bold}${'═'.repeat(80)}${C.reset}`);

--- a/backend/src/shared/lib/zk-driver.ts
+++ b/backend/src/shared/lib/zk-driver.ts
@@ -210,14 +210,13 @@ export class ZKDriver {
      * Returns true if a template exists on the device, false otherwise.
      */
     async hasFingerTemplate(uid: number, fingerIndex: number): Promise<boolean> {
-        if (!this.zkInstance) throw new Error('Not connected');
-        const { COMMANDS } = require('node-zklib/constants');
         try {
-            const buf = Buffer.alloc(3);
-            buf.writeUInt16LE(uid, 0);
-            buf.writeUInt8(fingerIndex, 2);
-            const result = await this.zkInstance.executeCmd(COMMANDS.CMD_USERTEMP_RRQ, buf);
-            return !!(result && result.length > 8);
+            const template = await this.getFingerTemplate(uid, fingerIndex);
+            if (template && template.length > 0) {
+                template.fill(0);
+                return true;
+            }
+            return false;
         } catch {
             return false;
         }
@@ -528,6 +527,12 @@ export class ZKDriver {
 
             // Step 9: Unlock machine
             await zkInfo.executeCmd(COMMANDS.CMD_ENABLEDEVICE, '');
+
+            // Step 10: Verify template actually exists on the device
+            const verifySuccess = await this.hasFingerTemplate(uid, fingerIndex);
+            if (!verifySuccess) {
+                throw new Error(`Device rejected or failed to write fingerprint template on slot ${fingerIndex}`);
+            }
 
             console.log(`[ZKDriver] Successfully synchronized fingerprint for UID: ${uid}`);
         } catch (error: unknown) {

--- a/frontend/src/features/attendance/components/AttendanceDesktopTable.tsx
+++ b/frontend/src/features/attendance/components/AttendanceDesktopTable.tsx
@@ -3,6 +3,7 @@ import { AlertCircle, Edit2, Fingerprint, PenLine, AlertTriangle, Trash2, Clock,
 import { SortableHeader } from '@/components/ui/SortableHeader'
 import { fmtHours, formatLate, fmtMins } from '../utils/attendance-formatters'
 import { AttendanceRecord } from '../types'
+import { getStatusBadges } from '../utils/attendance-logic'
 
 interface AttendanceDesktopTableProps {
   loading: boolean
@@ -325,22 +326,17 @@ export function AttendanceDesktopTable({
                 </td>
                 {/* Status */}
                 <td className="px-2 py-3 text-center">
-                  <div className="flex flex-col items-center justify-center gap-1">
-                    <span className={`font-black text-[10px] uppercase px-3 py-1 rounded-full border whitespace-nowrap ${
-                      row.isMerged                               ? 'text-slate-500 bg-slate-500/10 border-slate-500/20'
-                      : row.displayStatus === 'present'           ? 'text-emerald-500 bg-emerald-500/10 border-emerald-500/20'
-                      : row.displayStatus === 'IN_PROGRESS'      ? 'text-blue-500 bg-blue-500/10 border-blue-500/20'
-                      : row.displayStatus === 'late'             ? 'text-yellow-500 bg-yellow-500/10 border-yellow-500/20'
-                      : row.displayStatus === 'missing_checkout' ? 'text-amber-600 bg-amber-500/10 border-amber-500/20'
-                      : row.displayStatus === 'incomplete'       ? 'text-amber-500 bg-amber-500/10 border-amber-500/20'
-                      : row.displayStatus === 'pending'          ? 'text-slate-500 bg-slate-500/10 border-slate-500/20'
-                      : row.displayStatus === 'holiday'          ? 'text-indigo-500 bg-indigo-500/10 border-indigo-500/20'
-                      : row.displayStatus === 'rest_day'         ? 'text-slate-400 bg-slate-400/10 border-slate-400/20'
-                      : row.displayStatus === '—'                ? 'text-slate-500 bg-slate-500/10 border-slate-500/20'
-                      : 'text-red-500 bg-red-500/10 border-red-500/20'
-                    }`}>
-                      {row.isMerged ? 'Multiple Shifts' : row.displayStatus === 'present' ? 'On Time' : row.displayStatus === 'IN_PROGRESS' ? 'In Progress' : row.displayStatus === 'missing_checkout' ? 'Missing Checkout' : row.displayStatus === 'holiday' ? 'Holiday' : row.displayStatus === 'rest_day' ? 'Rest Day' : row.displayStatus}
-                    </span>
+                  <div className="flex flex-col items-center justify-center gap-1.5">
+                    <div className="flex flex-row flex-wrap justify-center items-center gap-1">
+                      {getStatusBadges(row).map((badge, idx) => (
+                        <span
+                          key={idx}
+                          className={`font-black text-[10px] uppercase px-2.5 py-0.5 rounded-full border whitespace-nowrap ${badge.className}`}
+                        >
+                          {badge.text}
+                        </span>
+                      ))}
+                    </div>
                     {row.isEdited && (
                       <span
                         title={row.notes || 'Manually adjusted'}

--- a/frontend/src/features/attendance/components/AttendanceMobileCards.tsx
+++ b/frontend/src/features/attendance/components/AttendanceMobileCards.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react'
 import { Edit2, Fingerprint, PenLine, AlertTriangle, Trash2, Clock, CreditCard } from 'lucide-react'
 import { fmtHours, formatLate, fmtMins } from '../utils/attendance-formatters'
 import { AttendanceRecord } from '../types'
+import { getStatusBadges } from '../utils/attendance-logic'
 
 interface AttendanceMobileCardsProps {
   loading: boolean
@@ -79,17 +80,14 @@ export function AttendanceMobileCards({
               </div>
             </div>
             <div className="flex items-center gap-2 shrink-0 flex-wrap justify-end">
-              <span className={`font-black text-[10px] uppercase px-3 py-1 rounded-full border whitespace-nowrap ${
-                row.displayStatus === 'present'           ? 'text-emerald-500 bg-emerald-500/10 border-emerald-500/20'
-                  : row.displayStatus === 'IN_PROGRESS'      ? 'text-blue-500 bg-blue-500/10 border-blue-500/20'
-                  : row.displayStatus === 'late'             ? 'text-yellow-500 bg-yellow-500/10 border-yellow-500/20'
-                  : row.displayStatus === 'missing_checkout' ? 'text-amber-600 bg-amber-500/10 border-amber-500/20'
-                  : row.displayStatus === 'rest_day'         ? 'text-slate-400 bg-slate-400/10 border-slate-400/20'
-                  : row.displayStatus === '—'                ? 'text-slate-500 bg-slate-500/10 border-slate-500/20'
-                  : 'text-red-500 bg-red-500/10 border-red-500/20'
-              }`}>
-                {row.displayStatus === 'present' ? 'On Time' : row.displayStatus === 'IN_PROGRESS' ? 'In Progress' : row.displayStatus === 'missing_checkout' ? 'Missing Checkout' : row.displayStatus === 'rest_day' ? 'Rest Day' : row.displayStatus}
-              </span>
+              {getStatusBadges(row).map((badge, idx) => (
+                <span
+                  key={idx}
+                  className={`font-black text-[10px] uppercase px-3 py-1 rounded-full border whitespace-nowrap ${badge.className}`}
+                >
+                  {badge.text}
+                </span>
+              ))}
               {row.isEdited && (
                 <span 
                   title={row.notes || 'Manually adjusted'}

--- a/frontend/src/features/attendance/hooks/useAttendanceDashboard.ts
+++ b/frontend/src/features/attendance/hooks/useAttendanceDashboard.ts
@@ -8,6 +8,7 @@ import { useTableSort } from '@/hooks/useTableSort'
 import { useAttendanceStream, AttendanceStreamPayload } from '@/features/attendance/hooks/useAttendanceStream'
 import { fmtHours, formatLate, fmtMins, toTimeInput } from '@/features/attendance/utils/attendance-formatters'
 import { AttendanceRecord, AttendanceConflict } from '@/features/attendance/types'
+import { processAttendanceData } from '@/features/attendance/utils/attendance-logic'
 import * as XLSX from 'xlsx'
 
 interface RawAttendanceLog {
@@ -66,6 +67,7 @@ interface RawEmployee {
   Shift?: { name?: string; shiftCode: string; isNightShift: boolean; startTime?: string; endTime?: string; workDays?: string }
   EmployeeShift?: { shift: { id: number; name: string; shiftCode: string; isNightShift: boolean; startTime?: string; endTime?: string; workDays?: string } }[]
   profilePicture?: string | null
+  hireDate?: string
 }
 
 interface EditRequestBody {
@@ -164,6 +166,8 @@ export function useAttendanceDashboard(role: 'admin' | 'hr' | 'manager') {
     { value: 'all', label: 'All Status' },
     { value: 'present', label: 'On Time' },
     { value: 'late', label: 'Late' },
+    { value: 'undertime', label: 'Undertime' },
+    { value: 'overtime', label: 'Overtime' },
     { value: 'absent', label: 'Absent' },
     { value: 'rest_day', label: 'Rest Day' },
     { value: 'incomplete', label: 'Missing Checkout' },
@@ -177,7 +181,16 @@ export function useAttendanceDashboard(role: 'admin' | 'hr' | 'manager') {
     if (branchQuery) setBranchFilter(branchQuery)
     if (statusQuery) {
       const s = statusQuery.toLowerCase()
-      setStatusFilter(s === 'present' ? 'present' : s === 'late' ? 'late' : s === 'absent' ? 'absent' : 'all')
+      setStatusFilter(
+        s === 'present' ? 'present'
+        : s === 'late' ? 'late'
+        : s === 'absent' ? 'absent'
+        : s === 'undertime' ? 'undertime'
+        : s === 'overtime' ? 'overtime'
+        : s === 'incomplete' ? 'incomplete'
+        : s === 'rest_day' ? 'rest_day'
+        : 'all'
+      )
     }
   }, [searchParams])
 
@@ -290,21 +303,14 @@ export function useAttendanceDashboard(role: 'admin' | 'hr' | 'manager') {
         }
       } catch { /* ignore holiday fetch errors */ }
 
-      // Helper: does a holiday apply to a given employee's branchId?
-      const holidayAppliesTo = (holiday: RawHoliday, branchId?: number | null) => {
-        if (!holiday?.branches || holiday.branches.length === 0) return true // National
-        if (!branchId) return true // No branch = treat as affected
-        return holiday.branches.some(b => b.branchId === branchId)
-      }
-
       setIsHolidayDate(dateIsHoliday)
 
+      // Always fetch all records for the selected date to compute correct absent rows
       const params = new URLSearchParams({
         startDate: selectedDate,
         endDate: selectedDate,
         limit: '10000',
       })
-      if (statusFilter !== 'all') params.append('status', statusFilter)
 
       const res = await fetch(`/api/attendance?${params}`, { 
         credentials: 'include', 
@@ -316,74 +322,6 @@ export function useAttendanceDashboard(role: 'admin' | 'hr' | 'manager') {
 
       const data = await res.json()
       if (data.success) {
-        const userRecords = data.data.filter((log: RawAttendanceLog) => {
-          const emp = log.employee
-          return !emp || emp.role === 'USER' || !emp.role
-        })
-
-        const mapped: AttendanceRecord[] = userRecords.map((log: RawAttendanceLog) => {
-          const emp = log.employee
-          const isPending = log.isPending === true
-          const isPendingManualCreation = isPending && log.notes?.includes('[Pending] Manual creation');
-
-          const checkIn = log.checkInTime ? new Date(log.checkInTime) : new Date()
-          const checkOut = log.checkOutTime ? new Date(log.checkOutTime) : null
-          // OT-only records (no shift assigned, but has approved overtime) should not display
-          // regular hours — all time worked belongs to overtime, not a regular shift.
-          const isOtOnlyRecord = !log.shift && !log.shiftId && !log.shiftCode && (log.approvedOts && log.approvedOts.length > 0)
-          const totalHours: number = (isPendingManualCreation || isOtOnlyRecord) ? 0 : (log.totalHours ?? (checkOut ? (checkOut.getTime() - checkIn.getTime()) / (1000 * 60 * 60) : 0))
-          const lateMinutes: number = isPendingManualCreation ? 0 : (log.lateMinutes ?? 0)
-          const overtimeMinutes: number = isPendingManualCreation ? 0 : (log.overtimeMinutes ?? 0)
-          const undertimeMinutes: number = isPendingManualCreation ? 0 : (log.undertimeMinutes ?? 0)
-          const shiftCode: string | null = log.shift?.shiftCode ?? log.shiftCode ?? emp?.Shift?.shiftCode ?? null
-          const shiftId: number | null = log.shift?.id ?? log.shiftId ?? null
-          const shiftName: string | null = log.shift?.name ?? null
-          const isAnomaly: boolean = isPendingManualCreation ? false : (log.isAnomaly ?? false)
-          const isEarlyOut: boolean = isPendingManualCreation ? false : (log.isEarlyOut ?? false)
-          const isShiftActive: boolean = isPendingManualCreation ? false : (log.isShiftActive ?? false)
-          const gracePeriodApplied: boolean = log.gracePeriodApplied ?? false
-          let computedStatus = isEarlyOut ? 'early-out' : isAnomaly ? 'anomaly' : lateMinutes > 0 ? 'late' : undertimeMinutes > 0 ? 'undertime' : (log.status || 'present')
-          const hasMissingCheckout = log.checkOutTime === null && log.status === 'incomplete';
-
-          let displayStatus = isShiftActive ? 'IN_PROGRESS' : hasMissingCheckout ? 'missing_checkout' : computedStatus
-
-          if (isPendingManualCreation) {
-            computedStatus = 'absent'
-            displayStatus = 'absent'
-          }
-
-          return {
-            id: log.id,
-            employeeId: log.employeeId,
-            employeeName: emp?.firstName ? `${emp.firstName}${emp.middleName ? ` ${emp.middleName[0]}.` : ''} ${emp.lastName}${emp.suffix ? ` ${emp.suffix}` : ''}` : 'Unknown',
-            profilePicture: emp?.profilePicture,
-            department: emp?.Department?.name || 'General',
-            sectionName: emp?.Section?.name || '—',
-            branchName: emp?.Branch?.name || '—',
-            date: new Date(log.date).toLocaleDateString('en-CA', { timeZone: 'Asia/Manila' }),
-            checkIn: isPendingManualCreation ? '—' : (log.checkInTime ? checkIn.toLocaleTimeString('en-US', { timeZone: 'Asia/Manila', hour: '2-digit', minute: '2-digit', hour12: true }) : '—'),
-            checkOut: isPendingManualCreation ? '—' : (checkOut ? checkOut.toLocaleTimeString('en-US', { timeZone: 'Asia/Manila', hour: '2-digit', minute: '2-digit', hour12: true }) : '—'),
-            status: computedStatus, 
-            displayStatus, lateMinutes, totalHours, overtimeMinutes, undertimeMinutes,
-            shiftId,
-            shiftCode,
-            shiftName,
-            shiftStartTime: log.shift?.startTime ?? emp?.Shift?.startTime,
-            shiftEndTime: log.shift?.endTime ?? emp?.Shift?.endTime,
-            isNightShift: log.shift?.isNightShift ?? emp?.Shift?.isNightShift ?? false,
-            isAnomaly, isEarlyOut, isShiftActive, gracePeriodApplied,
-            notes: log.notes || null,
-            isEarlyPunch: log.isEarlyPunch ?? false,
-            isMissingCheckout: log.isMissingCheckout ?? false,
-            checkInDevice: log.checkInDeviceName ?? null,
-            checkOutDevice: log.checkOutDeviceName ?? null,
-            checkoutSource: log.checkoutSource ?? null,
-            isEdited: log.isEdited ?? false,
-            isPending,
-            approvedOts: log.approvedOts,
-          }
-        })
-
         // Fetch all active employees to inject absent rows
         let allEmployees: RawEmployee[] = []
         try {
@@ -394,149 +332,86 @@ export function useAttendanceDashboard(role: 'admin' | 'hr' | 'manager') {
           )
         } catch { /* ignore */ }
 
-        // Build employee → company lookup for company filtering on attendance records
-        const companyByEmployeeId = new Map<number, string | null>()
-        for (const e of allEmployees) {
-          companyByEmployeeId.set(e.id, e.Company?.name ?? null)
-        }
+        // Filter out manager or admin logs (only keep USER logs)
+        const userRecords = data.data.filter((log: RawAttendanceLog) => {
+          const emp = log.employee
+          return !emp || emp.role === 'USER' || !emp.role
+        })
 
-        // Stamp companyName onto each mapped attendance record
-        for (const r of mapped) {
-          (r as any).companyName = companyByEmployeeId.get(r.employeeId) ?? null
-        }
+        // Call the unified data processing utility
+        const { records: processedRecords } = processAttendanceData(
+          userRecords,
+          allEmployees,
+          selectedDate,
+          matchedHoliday ? [matchedHoliday] : []
+        )
 
-        // Pending manual creations should NOT count as "present" for absent-row injection.
-        // Records with UPDATE/DELETE adjustments (isPending + real status) still count as present.
-        // Only brand-new unapproved creation placeholders (isPending + notes flag) are excluded.
-        const isPendingManualCreation = (r: AttendanceRecord) =>
-          r.isPending === true && (r.notes ?? '').includes('[Pending] Manual creation')
+        // Apply client-side filters (except status and shift for overall stats)
+        let filtered = processedRecords;
 
-        // Track which specific shifts have attendance records per employee.
-        // This ensures multi-shift employees only skip absent rows for shifts
-        // that already have records (not ALL shifts if they have ANY record).
-        const presentShiftsByEmployee = new Map<number, Set<number | null>>()
-        for (const r of mapped) {
-          if (isPendingManualCreation(r)) continue
-          if (!presentShiftsByEmployee.has(r.employeeId)) {
-            presentShiftsByEmployee.set(r.employeeId, new Set())
-          }
-          presentShiftsByEmployee.get(r.employeeId)!.add(r.shiftId)
-        }
-        // Also keep a simple "has any record" set for employees without multi-shift
-        const presentIds = new Set(mapped.filter(r => !isPendingManualCreation(r)).map(r => r.employeeId))
-
-        const todayStr = new Date().toLocaleDateString('en-CA', { timeZone: 'Asia/Manila' })
-        const isFutureDate = selectedDate > todayStr
-
-        // Helper: determine if the selected date is a working day for a given employee
-        const selectedDayName = new Date(selectedDate + 'T00:00:00Z')
-          .toLocaleDateString('en-US', { weekday: 'short', timeZone: 'UTC' })
-
-        /** Check if a specific shift's workDays includes the selected day */
-        const isWorkDayForShift = (workDays?: string): boolean => {
-          if (workDays) {
-            try {
-              const wDays = typeof workDays === 'string' ? JSON.parse(workDays) : workDays
-              if (Array.isArray(wDays)) return wDays.includes(selectedDayName)
-            } catch { /* fallback to default */ }
-          }
-          // Default: Mon-Fri are working days
-          return ['Mon', 'Tue', 'Wed', 'Thu', 'Fri'].includes(selectedDayName)
-        }
-
-        const isWorkingDayForEmployee = (emp: RawEmployee): boolean => {
-          // Check all assigned shifts via EmployeeShift junction table
-          if (emp.EmployeeShift && emp.EmployeeShift.length > 0) {
-            return emp.EmployeeShift.some(es => isWorkDayForShift(es.shift.workDays))
-          }
-          // Fallback to legacy primary shift
-          return isWorkDayForShift(emp.Shift?.workDays)
-        }
-
-        // Build absent/rest-day rows — one per assigned shift so employees
-        // appear in ALL their shift tabs, not just the primary.
-        const absentRows: AttendanceRecord[] = isFutureDate
-          ? []
-          : allEmployees
-            .filter((e: RawEmployee) => {
-              if (matchedHoliday && holidayAppliesTo(matchedHoliday, e.branchId)) return false
-              return true
-            })
-            .flatMap((e: RawEmployee) => {
-              const employeePresentShifts = presentShiftsByEmployee.get(e.id)
-
-              // Get all assigned shifts, falling back to legacy Shift
-              const shifts = (e.EmployeeShift && e.EmployeeShift.length > 0)
-                ? e.EmployeeShift.map(es => es.shift)
-                : (e.Shift ? [e.Shift] : [{ id: null as number | null, name: null as string | null, shiftCode: null as string | null, isNightShift: false, startTime: undefined as string | undefined, endTime: undefined as string | undefined, workDays: undefined as string | undefined }])
-
-              return shifts
-                .filter(shift => {
-                  // Skip this shift if the employee already has an attendance record for it
-                  const shiftId = (shift as any).id ?? null
-                  if (employeePresentShifts?.has(shiftId)) return false
-                  // For employees without EmployeeShift, skip entirely if they have any record
-                  if (!(e.EmployeeShift && e.EmployeeShift.length > 0) && presentIds.has(e.id)) return false
-                  return true
-                })
-                .map((shift, idx) => {
-                  const isWorking = isWorkDayForShift(shift.workDays)
-                  const rowStatus = isWorking ? 'absent' : 'rest_day'
-                  return {
-                    id: `absent-${e.id}${idx > 0 ? `-s${idx}` : ''}`,
-                    employeeId: e.id,
-                    employeeName: `${e.firstName} ${e.lastName}`,
-                    profilePicture: e.profilePicture,
-                    department: e.Department?.name || 'General',
-                    sectionName: e.Section?.name || '—',
-                    branchName: e.Branch?.name || '—',
-                    companyName: e.Company?.name ?? null,
-                    date: selectedDate,
-                    checkIn: '—', checkOut: '—', status: rowStatus, displayStatus: rowStatus,
-                    lateMinutes: 0, totalHours: 0, overtimeMinutes: 0, undertimeMinutes: 0,
-                    shiftId: null,
-                    shiftCode: shift.shiftCode ?? null,
-                    shiftName: shift.name ?? null,
-                    shiftStartTime: shift.startTime,
-                    shiftEndTime: shift.endTime,
-                    isNightShift: shift.isNightShift ?? false,
-                    isAnomaly: false, isEarlyOut: false, isShiftActive: false, gracePeriodApplied: false,
-                    isEarlyPunch: false, isMissingCheckout: false,
-                  }
-                })
-            })
-
-        // All mapped records (including pending manual creations) go into the table so the PR badge
-        // is visible — consistent with how UPDATE/DELETE adjustment records are displayed.
-        let full = (statusFilter === 'all' || statusFilter === 'absent' || statusFilter === 'rest_day')
-          ? [...mapped, ...absentRows]
-          : [...mapped]
-
-        // When filtering by 'absent' or 'rest_day', exclude the other type
-        if (statusFilter === 'absent') full = full.filter(r => r.status !== 'rest_day')
-        if (statusFilter === 'rest_day') full = full.filter(r => r.status !== 'absent' && r.status !== 'present' && r.status !== 'late' && r.status !== 'incomplete')
-
-        // Apply client-side filters
         if (debouncedSearch) {
           const q = debouncedSearch.toLowerCase()
-          full = full.filter(r => r.employeeName.toLowerCase().includes(q) || (r.shiftCode ?? '').toLowerCase().includes(q) || (r.shiftName ?? '').toLowerCase().includes(q))
+          filtered = filtered.filter(r => r.employeeName.toLowerCase().includes(q) || (r.shiftCode ?? '').toLowerCase().includes(q) || (r.shiftName ?? '').toLowerCase().includes(q))
         }
-        // Company filter: use direct companyName — null-company employees excluded from specific tabs
-        if (companyFilter !== 'All Companies') {
-          full = full.filter(r => (r as any).companyName === companyFilter)
-        }
-        if (branchFilter !== 'All Branches') full = full.filter(r => r.branchName === branchFilter)
-        if (deptFilter !== allDeptLabel) full = full.filter(r => r.department === deptFilter)
-        if (sectionFilter !== 'All Sections') full = full.filter(r => r.sectionName === sectionFilter)
 
-        // Extract available shifts from the filtered (by department/branch/etc) list before applying shiftFilter.
-        // NOTE: 'OT Approved' is intentionally excluded from the tab list — clicking the OT Approved badge
-        // in the Shift column redirects directly to Manage OT / Live Monitoring instead of filtering here.
+        if (companyFilter !== 'All Companies') {
+          filtered = filtered.filter(r => (r as any).companyName === companyFilter)
+        }
+        if (branchFilter !== 'All Branches') filtered = filtered.filter(r => r.branchName === branchFilter)
+        if (deptFilter !== allDeptLabel) filtered = filtered.filter(r => r.department === deptFilter)
+        if (sectionFilter !== 'All Sections') filtered = filtered.filter(r => r.sectionName === sectionFilter)
+
+        // --- Calculate Stats on the filtered subset (before status and shift filters) ---
+        const statsRecords = filtered.filter(r => r.isPending !== true || !(r.notes ?? '').includes('[Pending] Manual creation'))
+        const empGroups = new Map<number, typeof statsRecords>()
+        statsRecords.forEach(r => {
+          const list = empGroups.get(r.employeeId) || []
+          list.push(r)
+          empGroups.set(r.employeeId, list)
+        })
+
+        let onTime = 0
+        let late = 0
+        let absent = 0
+        let restDay = 0
+        let incomplete = 0
+
+        empGroups.forEach((recs) => {
+          const checkedIn = recs.filter(r => r.status !== 'absent' && r.status !== 'rest_day')
+          if (checkedIn.length > 0) {
+            const hasLate = checkedIn.some(r => r.lateMinutes > 0)
+            if (hasLate) {
+              late++
+            } else {
+              onTime++
+            }
+            if (checkedIn.some(r => r.status === 'incomplete' || r.displayStatus === 'missing_checkout')) {
+              incomplete++
+            }
+          } else {
+            const isWorking = recs.some(r => r.status === 'absent')
+            if (isWorking) {
+              absent++
+            } else {
+              restDay++
+            }
+          }
+        })
+
+        const total = onTime + late + absent + restDay
+        const avgHours = statsRecords.length > 0
+          ? (statsRecords.filter(r => r.totalHours > 0).reduce((s, r) => s + r.totalHours, 0) /
+            (statsRecords.filter(r => r.totalHours > 0).length || 1)).toFixed(1) : '0'
+        const totalOT = (statsRecords.reduce((s, r) => s + (r.overtimeMinutes ?? 0), 0) / 60).toFixed(1)
+        const totalUT = (statsRecords.reduce((s, r) => s + (r.undertimeMinutes ?? 0), 0) / 60).toFixed(1)
+
+        setStats({ onTime, late, absent, restDay, incomplete, total, avgHours, totalOT, totalUT })
+
+        // Extract available shifts from the filtered list (before shiftFilter is applied)
         const uniqueShifts = new Set<string>()
         const shiftStartTimes = new Map<string, string>()
         
-        for (const r of full) {
-          // OT-only records (no shift, but has approved OT) are grouped under 'No Shift' for tab purposes
+        for (const r of filtered) {
           const shiftKey = r.shiftName ?? r.shiftCode ?? 'No Shift'
           uniqueShifts.add(shiftKey)
           if (!shiftStartTimes.has(shiftKey) && r.shiftStartTime) {
@@ -554,7 +429,30 @@ export function useAttendanceDashboard(role: 'admin' | 'hr' | 'manager') {
         
         setAvailableShifts(['All Shifts', ...sortedShifts])
 
-        if (shiftFilter !== 'All Shifts') full = full.filter(r => (r.shiftName ?? r.shiftCode ?? 'No Shift') === shiftFilter)
+        // Apply client-side shift filter
+        let full = filtered
+        if (shiftFilter !== 'All Shifts') {
+          full = full.filter(r => (r.shiftName ?? r.shiftCode ?? 'No Shift') === shiftFilter)
+        }
+
+        // Apply client-side status filter
+        if (statusFilter !== 'all') {
+          if (statusFilter === 'present') {
+            full = full.filter(r => r.status !== 'absent' && r.status !== 'rest_day' && r.status !== 'holiday' && r.lateMinutes === 0)
+          } else if (statusFilter === 'late') {
+            full = full.filter(r => r.status !== 'absent' && r.status !== 'rest_day' && r.status !== 'holiday' && r.lateMinutes > 0)
+          } else if (statusFilter === 'undertime') {
+            full = full.filter(r => r.undertimeMinutes > 0)
+          } else if (statusFilter === 'overtime') {
+            full = full.filter(r => r.overtimeMinutes > 0)
+          } else if (statusFilter === 'absent') {
+            full = full.filter(r => r.status === 'absent')
+          } else if (statusFilter === 'incomplete') {
+            full = full.filter(r => r.status === 'incomplete' || r.displayStatus === 'missing_checkout')
+          } else if (statusFilter === 'rest_day') {
+            full = full.filter(r => r.status === 'rest_day')
+          }
+        }
 
         // --- MERGE MULTIPLE SHIFTS FOR "ALL SHIFTS" VIEW ---
         if (shiftFilter === 'All Shifts') {
@@ -576,13 +474,15 @@ export function useAttendanceDashboard(role: 'admin' | 'hr' | 'manager') {
                 return timeA.localeCompare(timeB);
               });
               const primary = sortedGroup[0]
+              
+              const hasLate = sortedGroup.some(g => g.status === 'late')
               mergedFull.push({
                 ...primary,
                 id: `merged-${primary.employeeId}-${primary.date}`,
                 isMerged: true,
                 subRecords: sortedGroup,
-                status: 'Multiple',
-                displayStatus: 'Multiple',
+                status: hasLate ? 'late' : 'present',
+                displayStatus: hasLate ? 'late' : 'present',
                 shiftCode: sortedGroup.map(g => g.shiftCode).filter(Boolean).join(', '),
                 totalHours: group.reduce((sum, r) => sum + r.totalHours, 0),
                 lateMinutes: group.reduce((sum, r) => sum + r.lateMinutes, 0),
@@ -594,27 +494,9 @@ export function useAttendanceDashboard(role: 'admin' | 'hr' | 'manager') {
           }
           full = mergedFull
         }
-        // ----------------------------------------------------
 
         setRecords(full)
         setTotalPages(Math.max(1, Math.ceil(full.length / ROW_PER_PAGE)))
-
-        // Stats: exclude pending manual creation records — they are unapproved and must not
-        // inflate or deflate any stat counter (present, late, absent, hours, etc.).
-        const statsRecords = full.filter(r => !isPendingManualCreation(r))
-        setStats({
-          onTime: statsRecords.filter(r => r.status === 'present' || r.status === 'IN_PROGRESS').length,
-          late: statsRecords.filter(r => r.status === 'late').length,
-          absent: statsRecords.filter(r => r.status === 'absent').length,
-          restDay: statsRecords.filter(r => r.status === 'rest_day').length,
-          incomplete: statsRecords.filter(r => r.status === 'incomplete' || r.displayStatus === 'missing_checkout').length,
-          total: statsRecords.length,
-          avgHours: statsRecords.length > 0
-            ? (statsRecords.filter(r => r.totalHours > 0).reduce((s, r) => s + r.totalHours, 0) /
-              (statsRecords.filter(r => r.totalHours > 0).length || 1)).toFixed(1) : '0',
-          totalOT: (statsRecords.reduce((s, r) => s + (r.overtimeMinutes ?? 0), 0) / 60).toFixed(1),
-          totalUT: (statsRecords.reduce((s, r) => s + (r.undertimeMinutes ?? 0), 0) / 60).toFixed(1),
-        })
       } else {
         setError(data.message || 'Failed to fetch attendance')
       }

--- a/frontend/src/features/attendance/hooks/useAttendanceDashboard.ts
+++ b/frontend/src/features/attendance/hooks/useAttendanceDashboard.ts
@@ -112,7 +112,7 @@ export function useAttendanceDashboard(role: 'admin' | 'hr' | 'manager') {
   const [companiesList, setCompaniesList] = useState<{ id: number; name: string }[]>([])
   const [companyFilter, setCompanyFilter] = useState('All Companies')
   const [departmentsList, setDepartmentsList] = useState<{ id: number; name: string }[]>([])
-  const [sectionsList, setSectionsList] = useState<{ id: number; name: string; departmentId: number }[]>([])
+  const [sectionsList, setSectionsList] = useState<{ id: number; name: string; departments?: { departmentId: number }[] }[]>([])
   const [stats, setStats] = useState({ onTime: 0, late: 0, absent: 0, restDay: 0, incomplete: 0, total: 0, avgHours: '0', totalOT: '0', totalUT: '0' })
   const [availableShifts, setAvailableShifts] = useState<string[]>(['All Shifts'])
 
@@ -156,7 +156,7 @@ export function useAttendanceDashboard(role: 'admin' | 'hr' | 'manager') {
     if (deptFilter === allDeptLabel) return sectionsList;
     const dept = departmentsList.find(d => d.name === deptFilter);
     if (!dept) return [];
-    return sectionsList.filter(s => s.departmentId === dept.id);
+    return sectionsList.filter(s => s.departments?.some(d => d.departmentId === dept.id));
   }, [sectionsList, departmentsList, deptFilter, allDeptLabel]);
 
   const sections = ['All Sections', ...filteredSectionsList.map(s => s.name)]

--- a/frontend/src/features/attendance/utils/attendance-logic.ts
+++ b/frontend/src/features/attendance/utils/attendance-logic.ts
@@ -1,0 +1,344 @@
+import { AttendanceRecord } from '../types';
+
+export function formatEmployeeName(emp?: { firstName: string; middleName?: string; lastName: string; suffix?: string }) {
+  if (!emp) return 'Unknown';
+  const firstName = emp.firstName || '';
+  const lastName = emp.lastName || '';
+  const mid = emp.middleName ? ` ${emp.middleName.trim()[0]}.` : '';
+  const suf = emp.suffix ? ` ${emp.suffix.trim()}` : '';
+  return `${firstName.trim()}${mid} ${lastName.trim()}${suf}`.trim();
+}
+
+export function processAttendanceData(
+  rawLogs: any[],
+  employees: any[],
+  selectedDate: string,
+  holidays: any[]
+): {
+  records: AttendanceRecord[];
+  stats: {
+    onTime: number;
+    late: number;
+    absent: number;
+    restDay: number;
+    incomplete: number;
+    total: number;
+    avgHours: string;
+    totalOT: string;
+    totalUT: string;
+  };
+} {
+  // 1. Identify holiday that applies to this date
+  const matchedHoliday = holidays.find(
+    (h) => new Date(h.date).toISOString().split('T')[0] === selectedDate
+  );
+
+  const holidayAppliesTo = (holiday: any, branchId?: number | null) => {
+    if (!holiday?.branches || holiday.branches.length === 0) return true; // National
+    if (!branchId) return true; // No branch = treat as affected
+    return holiday.branches.some((b: any) => b.branchId === branchId);
+  };
+
+  const isPendingManualCreation = (r: any) =>
+    r.isPending === true && (r.notes ?? '').includes('[Pending] Manual creation');
+
+  // 2. Map existing logs
+  const mapped: AttendanceRecord[] = rawLogs.map((log: any) => {
+    const emp = log.employee || log.Employee;
+    const isPending = log.isPending === true;
+    const pendingManual = isPending && log.notes?.includes('[Pending] Manual creation');
+
+    const checkIn = log.checkInTime ? new Date(log.checkInTime) : new Date();
+    const checkOut = log.checkOutTime ? new Date(log.checkOutTime) : null;
+    const isOtOnlyRecord = !log.shift && !log.shiftId && !log.shiftCode && (log.approvedOts && log.approvedOts.length > 0);
+
+    const totalHours: number = (pendingManual || isOtOnlyRecord) ? 0 : (log.totalHours ?? (checkOut ? (checkOut.getTime() - checkIn.getTime()) / (1000 * 60 * 60) : 0));
+    const lateMinutes: number = pendingManual ? 0 : (log.lateMinutes ?? 0);
+    const overtimeMinutes: number = pendingManual ? 0 : (log.overtimeMinutes ?? 0);
+    const undertimeMinutes: number = pendingManual ? 0 : (log.undertimeMinutes ?? 0);
+
+    const shiftCode: string | null = log.shift?.shiftCode ?? log.shiftCode ?? emp?.Shift?.shiftCode ?? null;
+    const shiftId: number | null = log.shift?.id ?? log.shiftId ?? null;
+    const shiftName: string | null = log.shift?.name ?? null;
+
+    const isAnomaly: boolean = pendingManual ? false : (log.isAnomaly ?? false);
+    const isEarlyOut: boolean = pendingManual ? false : (log.isEarlyOut ?? false);
+    const isShiftActive: boolean = pendingManual ? false : (log.isShiftActive ?? false);
+    const gracePeriodApplied: boolean = log.gracePeriodApplied ?? false;
+
+    let computedStatus = isEarlyOut ? 'early-out' : isAnomaly ? 'anomaly' : lateMinutes > 0 ? 'late' : undertimeMinutes > 0 ? 'undertime' : (log.status || 'present');
+    const hasMissingCheckout = log.checkOutTime === null && log.status === 'incomplete';
+
+    let displayStatus = isShiftActive ? 'IN_PROGRESS' : hasMissingCheckout ? 'missing_checkout' : computedStatus;
+
+    if (pendingManual) {
+      computedStatus = 'absent';
+      displayStatus = 'absent';
+    }
+
+    return {
+      id: log.id,
+      employeeId: log.employeeId,
+      employeeName: formatEmployeeName(emp),
+      profilePicture: emp?.profilePicture || null,
+      department: emp?.Department?.name || 'General',
+      sectionName: emp?.Section?.name || '—',
+      branchName: emp?.Branch?.name || '—',
+      companyName: emp?.Company?.name || null,
+      date: new Date(log.date).toLocaleDateString('en-CA', { timeZone: 'Asia/Manila' }),
+      checkIn: pendingManual ? '—' : (log.checkInTime ? checkIn.toLocaleTimeString('en-US', { timeZone: 'Asia/Manila', hour: '2-digit', minute: '2-digit', hour12: true }) : '—'),
+      checkOut: pendingManual ? '—' : (checkOut ? checkOut.toLocaleTimeString('en-US', { timeZone: 'Asia/Manila', hour: '2-digit', minute: '2-digit', hour12: true }) : '—'),
+      status: computedStatus,
+      displayStatus,
+      lateMinutes,
+      totalHours,
+      overtimeMinutes,
+      undertimeMinutes,
+      shiftId,
+      shiftCode,
+      shiftName,
+      shiftStartTime: log.shift?.startTime ?? emp?.Shift?.startTime,
+      shiftEndTime: log.shift?.endTime ?? emp?.Shift?.endTime,
+      isNightShift: log.shift?.isNightShift ?? emp?.Shift?.isNightShift ?? false,
+      isAnomaly,
+      isEarlyOut,
+      isShiftActive,
+      gracePeriodApplied,
+      notes: log.notes || null,
+      isEarlyPunch: log.isEarlyPunch ?? false,
+      isMissingCheckout: log.isMissingCheckout ?? false,
+      checkInDevice: log.checkInDeviceName ?? log.checkInDevice?.name ?? null,
+      checkOutDevice: log.checkOutDeviceName ?? log.checkOutDevice?.name ?? null,
+      checkInAuthMethod: log.checkInAuthMethod || null,
+      checkOutAuthMethod: log.checkOutAuthMethod || null,
+      checkoutSource: log.checkoutSource ?? null,
+      isEdited: log.isEdited ?? !!(log.checkin_updated || log.checkout_updated),
+      isPending,
+      approvedOts: log.approvedOts || [],
+    };
+  });
+
+  // 3. Track present shifts by employee to inject absent rows
+  const presentShiftsByEmployee = new Map<number, Set<number | null>>();
+  for (const r of mapped) {
+    if (isPendingManualCreation(r)) continue;
+    if (!presentShiftsByEmployee.has(r.employeeId)) {
+      presentShiftsByEmployee.set(r.employeeId, new Set());
+    }
+    presentShiftsByEmployee.get(r.employeeId)!.add(r.shiftId);
+  }
+  const presentIds = new Set(mapped.filter(r => !isPendingManualCreation(r)).map(r => r.employeeId));
+  const hasAnyRecordIds = new Set(mapped.map(r => r.employeeId));
+
+  const todayStr = new Date().toLocaleDateString('en-CA', { timeZone: 'Asia/Manila' });
+  const isFutureDate = selectedDate > todayStr;
+
+  const selectedDayName = new Date(selectedDate + 'T00:00:00Z')
+    .toLocaleDateString('en-US', { weekday: 'short', timeZone: 'UTC' });
+
+  const isWorkDayForShift = (workDays?: string): boolean => {
+    if (workDays) {
+      try {
+        const wDays = typeof workDays === 'string' ? JSON.parse(workDays) : workDays;
+        if (Array.isArray(wDays)) return wDays.includes(selectedDayName);
+      } catch { }
+    }
+    return ['Mon', 'Tue', 'Wed', 'Thu', 'Fri'].includes(selectedDayName);
+  };
+
+  // 4. Inject absent/rest-day rows
+  const absentRows: AttendanceRecord[] = [];
+  if (!isFutureDate) {
+    for (const e of employees) {
+      // If employee already has any check-in record for the day, they are present! Skip absent injection completely.
+      if (presentIds.has(e.id)) continue;
+      // If they already have any record (e.g. pending manual creation), skip injecting new absent row
+      if (hasAnyRecordIds.has(e.id)) continue;
+
+      // Hire date check: skip if hired after selectedDate
+      if (e.hireDate) {
+        const hireDateStr = new Date(e.hireDate).toLocaleDateString('en-CA', { timeZone: 'Asia/Manila' });
+        if (selectedDate < hireDateStr) continue;
+      }
+
+      // Holiday check: skip if affected by holiday
+      if (matchedHoliday && holidayAppliesTo(matchedHoliday, e.branchId)) continue;
+
+      const employeePresentShifts = presentShiftsByEmployee.get(e.id);
+      const shifts = (e.EmployeeShift && e.EmployeeShift.length > 0)
+        ? e.EmployeeShift.map((es: any) => es.shift)
+        : (e.Shift ? [e.Shift] : [{ id: null, name: null, shiftCode: null, isNightShift: false, startTime: undefined, endTime: undefined, workDays: undefined }]);
+
+      shifts.forEach((shift: any, idx: number) => {
+        const shiftId = shift.id ?? null;
+        if (employeePresentShifts?.has(shiftId)) return;
+
+        const isWorking = isWorkDayForShift(shift.workDays);
+        const rowStatus = isWorking ? 'absent' : 'rest_day';
+
+        absentRows.push({
+          id: `absent-${e.id}${idx > 0 ? `-s${idx}` : ''}`,
+          employeeId: e.id,
+          employeeName: formatEmployeeName(e),
+          profilePicture: e.profilePicture || null,
+          department: e.Department?.name || 'General',
+          sectionName: e.Section?.name || '—',
+          branchName: e.Branch?.name || '—',
+          companyName: e.Company?.name || null,
+          date: selectedDate,
+          checkIn: '—',
+          checkOut: '—',
+          status: rowStatus,
+          displayStatus: rowStatus,
+          lateMinutes: 0,
+          totalHours: 0,
+          overtimeMinutes: 0,
+          undertimeMinutes: 0,
+          shiftId,
+          shiftCode: shift.shiftCode ?? null,
+          shiftName: shift.name ?? null,
+          shiftStartTime: shift.startTime,
+          shiftEndTime: shift.endTime,
+          isNightShift: shift.isNightShift ?? false,
+          isAnomaly: false,
+          isEarlyOut: false,
+          isShiftActive: false,
+          gracePeriodApplied: false,
+          approvedOts: [],
+        });
+      });
+    }
+  }
+
+  const allRecords = [...mapped, ...absentRows];
+
+  // 5. Calculate statistics from statsRecords (excluding pending manual creations)
+  const statsRecords = allRecords.filter(r => !isPendingManualCreation(r));
+
+  // Stats computation at employee level to keep it robust and consistent with totals
+  let onTime = 0;
+  let late = 0;
+  let absent = 0;
+  let restDay = 0;
+  let incomplete = 0;
+
+  for (const e of employees) {
+    // Hire date check
+    if (e.hireDate) {
+      const hireDateStr = new Date(e.hireDate).toLocaleDateString('en-CA', { timeZone: 'Asia/Manila' });
+      if (selectedDate < hireDateStr) continue;
+    }
+
+    // Holiday check
+    if (matchedHoliday && holidayAppliesTo(matchedHoliday, e.branchId)) continue;
+
+    const empRecords = statsRecords.filter((r) => r.employeeId === e.id);
+
+    if (empRecords.length > 0) {
+      // Checked in!
+      const hasLate = empRecords.some((r) => r.lateMinutes > 0);
+      if (hasLate) {
+        late++;
+      } else {
+        onTime++;
+      }
+
+      const hasIncomplete = empRecords.some(
+        (r) => r.status === 'incomplete' || r.displayStatus === 'missing_checkout'
+      );
+      if (hasIncomplete) {
+        incomplete++;
+      }
+    } else {
+      // Not checked in
+      const shifts = (e.EmployeeShift && e.EmployeeShift.length > 0)
+        ? e.EmployeeShift.map((es: any) => es.shift)
+        : (e.Shift ? [e.Shift] : [{ workDays: undefined }]);
+
+      const isWorking = shifts.some((s: any) => isWorkDayForShift(s.workDays));
+      if (isWorking) {
+        absent++;
+      } else {
+        restDay++;
+      }
+    }
+  }
+
+  const total = onTime + late + absent + restDay;
+
+  const avgHours = statsRecords.length > 0
+    ? (statsRecords.filter(r => r.totalHours > 0).reduce((s, r) => s + r.totalHours, 0) /
+      (statsRecords.filter(r => r.totalHours > 0).length || 1)).toFixed(1) : '0';
+
+  const totalOT = (statsRecords.reduce((s, r) => s + (r.overtimeMinutes ?? 0), 0) / 60).toFixed(1);
+  const totalUT = (statsRecords.reduce((s, r) => s + (r.undertimeMinutes ?? 0), 0) / 60).toFixed(1);
+
+  return {
+    records: allRecords,
+    stats: {
+      onTime,
+      late,
+      absent,
+      restDay,
+      incomplete,
+      total,
+      avgHours,
+      totalOT,
+      totalUT,
+    },
+  };
+}
+
+export interface StatusBadge {
+  text: string;
+  className: string;
+}
+
+export function getStatusBadges(row: AttendanceRecord): StatusBadge[] {
+  const badges: StatusBadge[] = [];
+
+  if (row.isMerged) {
+    badges.push({ text: 'Multiple Shifts', className: 'text-slate-500 bg-slate-500/10 border-slate-500/20' });
+    return badges;
+  }
+
+  if (row.isShiftActive) {
+    badges.push({ text: 'In Progress', className: 'text-blue-500 bg-blue-500/10 border-blue-500/20' });
+    return badges;
+  }
+
+  const status = row.status;
+  if (status === 'absent') {
+    badges.push({ text: 'Absent', className: 'text-red-500 bg-red-500/10 border-red-500/20' });
+    return badges;
+  }
+  if (status === 'rest_day') {
+    badges.push({ text: 'Rest Day', className: 'text-slate-400 bg-slate-400/10 border-slate-400/20' });
+    return badges;
+  }
+  if (status === 'holiday') {
+    badges.push({ text: 'Holiday', className: 'text-indigo-500 bg-indigo-500/10 border-indigo-500/20' });
+    return badges;
+  }
+  if (status === 'incomplete' || row.displayStatus === 'missing_checkout') {
+    badges.push({ text: 'Missing Checkout', className: 'text-amber-600 bg-amber-500/10 border-amber-500/20' });
+    return badges;
+  }
+
+  // Checked in record
+  if (row.lateMinutes > 0) {
+    badges.push({ text: 'Late', className: 'text-yellow-500 bg-yellow-500/10 border-yellow-500/20' });
+  } else {
+    badges.push({ text: 'On Time', className: 'text-emerald-500 bg-emerald-500/10 border-emerald-500/20' });
+  }
+
+  if (row.undertimeMinutes > 0) {
+    badges.push({ text: 'Undertime', className: 'text-red-500 bg-red-500/10 border-red-500/20' });
+  }
+  if (row.overtimeMinutes > 0) {
+    badges.push({ text: 'Overtime', className: 'text-emerald-600 bg-emerald-600/10 border-emerald-600/20' });
+  }
+
+  return badges;
+}
+

--- a/frontend/src/features/attendance/utils/attendance-logic.ts
+++ b/frontend/src/features/attendance/utils/attendance-logic.ts
@@ -332,13 +332,6 @@ export function getStatusBadges(row: AttendanceRecord): StatusBadge[] {
     badges.push({ text: 'On Time', className: 'text-emerald-500 bg-emerald-500/10 border-emerald-500/20' });
   }
 
-  if (row.undertimeMinutes > 0) {
-    badges.push({ text: 'Undertime', className: 'text-red-500 bg-red-500/10 border-red-500/20' });
-  }
-  if (row.overtimeMinutes > 0) {
-    badges.push({ text: 'Overtime', className: 'text-emerald-600 bg-emerald-600/10 border-emerald-600/20' });
-  }
-
   return badges;
 }
 

--- a/frontend/src/features/biometrics/components/FingerprintDeviceSyncPanel.tsx
+++ b/frontend/src/features/biometrics/components/FingerprintDeviceSyncPanel.tsx
@@ -83,6 +83,10 @@ export function FingerprintDeviceSyncPanel({
                         <span className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded bg-red-50 text-red-600 text-[9px] font-bold uppercase tracking-wider border border-red-100">
                           <AlertTriangle className="w-2.5 h-2.5" /> Pending Delete
                         </span>
+                      ) : device.syncStatus === 'partial' ? (
+                        <span className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded bg-orange-50 text-orange-700 text-[9px] font-bold uppercase tracking-wider border border-orange-100">
+                          <AlertTriangle className="w-2.5 h-2.5" /> Partially Synced
+                        </span>
                       ) : device.enrolled ? (
                         <span className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded bg-emerald-50 text-emerald-700 text-[9px] font-bold uppercase tracking-wider border border-emerald-100">
                           <Check className="w-2.5 h-2.5" /> Synced {device.enrolledAt ? `(${new Date(device.enrolledAt).toLocaleDateString()})` : ''}

--- a/frontend/src/features/biometrics/hooks/useFingerprintDashboard.ts
+++ b/frontend/src/features/biometrics/hooks/useFingerprintDashboard.ts
@@ -11,6 +11,7 @@ export interface DeviceSyncStatus {
   syncEnabled: boolean
   excluded: boolean
   pendingDeletion: boolean
+  syncStatus?: 'synced' | 'partial' | 'not_synced'
 }
 
 export interface FingerprintSlot {

--- a/frontend/src/features/dashboard/hooks/useDashboardData.ts
+++ b/frontend/src/features/dashboard/hooks/useDashboardData.ts
@@ -4,6 +4,7 @@ import { useEffect, useState, useCallback, useRef } from 'react';
 import { useRouter } from 'next/navigation';
 import { useAttendanceStream, AttendanceStreamPayload } from '@/features/attendance/hooks/useAttendanceStream';
 import { useDeviceStream, DeviceStatusPayload, DeviceConnectedPayload } from '@/features/devices/hooks/useDeviceStream';
+import { processAttendanceData } from '@/features/attendance/utils/attendance-logic';
 
 interface Branch { id: number; name: string; address?: string; }
 interface Device { id: number; name: string; ip: string; port: number; location?: string; isActive: boolean; syncEnabled: boolean; }
@@ -189,39 +190,14 @@ export function useDashboardData(role: 'admin' | 'hr') {
             const todayPHTStr = phtStr(new Date());
             const weeklyAll: WeekDay[] = weekDates.map(({ day, date }) => {
                 const dateStr = phtStr(date);
+                if (dateStr > todayPHTStr) return { day, present: 0, late: 0, absent: 0 };
                 const dayAtts = weekAtts.filter(a => {
                     const recDate = a.date ? phtStr(new Date(a.date)) : '';
                     return recDate === dateStr;
                 });
-
-                const late = dayAtts.filter(a => a.checkInTime && a.lateMinutes > 0).length;
-                // On Time = checked in AND not late (mutually exclusive with Late)
-                const onTime = dayAtts.filter(a => a.checkInTime && (a.lateMinutes ?? 0) === 0).length;
-                const totalCheckedIn = onTime + late;
-                const isDateHoliday = holidayDateSet.has(dateStr);
-                // Only count employees whose hireDate is on or before this day
-                const eligibleCount = activeEmps.filter((e: RawEmployee) => {
-                    if (!e.hireDate) return true; // no hireDate = always eligible
-                    return phtStr(new Date(e.hireDate)) <= dateStr;
-                }).length;
-                // Branch-aware holiday check: only exempt employees whose branch matches
-                const dayHoliday = holidayByDate.get(dateStr);
-                let absent: number;
-                if (dayHoliday) {
-                    // Count employees NOT affected by the holiday as potentially absent
-                    const nonHolidayEmps = activeEmps.filter((e: RawEmployee) => {
-                        if (e.hireDate && phtStr(new Date(e.hireDate)) > dateStr) return false;
-                        return !holidayApplies(dayHoliday, e.branchId);
-                    });
-                    const nonHolidayCheckedIn = dayAtts.filter(a => {
-                        const emp = (a.employee || a.Employee || {}) as Partial<RawEmployee>;
-                        return !holidayApplies(dayHoliday, emp.branchId) && a.checkInTime;
-                    }).length;
-                    absent = dateStr <= todayPHTStr ? Math.max(0, nonHolidayEmps.length - nonHolidayCheckedIn) : 0;
-                } else {
-                    absent = dateStr <= todayPHTStr ? Math.max(0, eligibleCount - totalCheckedIn) : 0;
-                }
-                return { day, present: onTime, late, absent };
+                const dayHolidays = holidayByDate.get(dateStr) ? [holidayByDate.get(dateStr)!] : [];
+                const { stats: dayStats } = processAttendanceData(dayAtts, activeEmps, dateStr, dayHolidays);
+                return { day, present: dayStats.onTime, late: dayStats.late, absent: dayStats.absent };
             });
             // Always show Mon–Sat; only show Sun if there is attendance data
             const weekly = weeklyAll.filter(d => {
@@ -252,20 +228,14 @@ export function useDashboardData(role: 'admin' | 'hr') {
             });
             setBranchPresence(bPresence);
 
-            const todayLate = atts.filter(a => a.checkInTime && a.lateMinutes > 0).length;
-            // On Time = checked in AND not late (mutually exclusive with Late)
-            const todayOnTime = atts.filter(a => a.checkInTime && !(a.lateMinutes > 0)).length;
-            const todayPresent = todayOnTime + todayLate; // total who checked in, used for absent calc
-            setTotalPresent(todayOnTime);
-            setTotalLate(todayLate);
-            // Only count employees whose hireDate is on or before today for absent/holiday calc
-            const todayEligible = activeEmps.filter((e: RawEmployee) => {
-                if (!e.hireDate) return true;
-                return phtStr(new Date(e.hireDate)) <= todayPHTStr;
-            }).length;
-            const missingCount = Math.max(0, todayEligible - todayPresent);
+            // Use unified processAttendanceData for today's stats
+            const todayHolidayArr = todayHoliday ? [todayHoliday] : [];
+            const { stats: todayStats } = processAttendanceData(atts, activeEmps, todayStr, todayHolidayArr);
+            setTotalPresent(todayStats.onTime);
+            setTotalLate(todayStats.late);
+            setTotalAbsent(todayStats.absent);
             if (todayHoliday) {
-                // Branch-aware: count how many employees are affected by today's holiday
+                // Count holiday-affected employees who didn't check in
                 const holidayAffected = activeEmps.filter((e: RawEmployee) => {
                     if (e.hireDate && phtStr(new Date(e.hireDate)) > todayPHTStr) return false;
                     return holidayApplies(todayHoliday, e.branchId);
@@ -274,15 +244,8 @@ export function useDashboardData(role: 'admin' | 'hr') {
                     const emp = (a.employee || a.Employee || {}) as Partial<RawEmployee>;
                     return holidayApplies(todayHoliday, emp.branchId) && a.checkInTime;
                 }).length;
-                const holidayMissing = Math.max(0, holidayAffected.length - holidayAffectedPresent);
-                // Non-holiday employees are absent normally
-                const nonHolidayEligible = todayEligible - holidayAffected.length;
-                const nonHolidayPresent = todayPresent - holidayAffectedPresent;
-                const nonHolidayAbsent = Math.max(0, nonHolidayEligible - nonHolidayPresent);
-                setTotalAbsent(nonHolidayAbsent);
-                setTotalHoliday(holidayMissing);
+                setTotalHoliday(Math.max(0, holidayAffected.length - holidayAffectedPresent));
             } else {
-                setTotalAbsent(missingCount);
                 setTotalHoliday(0);
             }
 

--- a/frontend/src/features/employees/components/EditAssignmentSection.tsx
+++ b/frontend/src/features/employees/components/EditAssignmentSection.tsx
@@ -61,7 +61,7 @@ export function EditAssignmentSection({
   const filteredSections = useMemo(() => {
     if (!editForm.departmentId) return []
     const deptId = Number(editForm.departmentId)
-    return sections.filter((s: any) => s.departmentId === deptId)
+    return sections.filter((s: any) => s.departments?.some((d: any) => d.departmentId === deptId))
   }, [sections, editForm.departmentId])
 
   // Filter branches by selected company

--- a/frontend/src/features/employees/components/EmployeeAddModal.tsx
+++ b/frontend/src/features/employees/components/EmployeeAddModal.tsx
@@ -46,7 +46,7 @@ export function EmployeeAddModal({ departments, branches, companies, shifts, onS
   const filteredSections = useMemo(() => {
     if (!newEmployee.departmentId) return [];
     const deptId = parseInt(newEmployee.departmentId, 10);
-    return sections.filter((s: any) => s.departmentId === deptId);
+    return sections.filter((s: any) => s.departments?.some((d: any) => d.departmentId === deptId));
   }, [sections, newEmployee.departmentId]);
 
   /** Parse workDays JSON and return compact day abbreviations */

--- a/frontend/src/features/employees/components/EmployeeFiltersBar.tsx
+++ b/frontend/src/features/employees/components/EmployeeFiltersBar.tsx
@@ -22,7 +22,7 @@ interface FilterState {
 interface EmployeeFiltersBarProps {
   filters: FilterState;
   departments: { id: number; name: string }[];
-  sections: { id: number; name: string; departmentId: number }[];
+  sections: { id: number; name: string; departments?: { departmentId: number }[] }[];
   branches: { id: number; name: string }[];
   shifts: { id: number; name: string }[];
   role?: 'admin' | 'hr' | 'manager';
@@ -33,7 +33,7 @@ export function EmployeeFiltersBar({ filters, departments, sections, branches, s
     if (!filters.selectedDept || filters.selectedDept === 'all') return sections;
     const dept = departments.find(d => d.name === filters.selectedDept);
     if (!dept) return [];
-    return sections.filter(s => s.departmentId === dept.id);
+    return sections.filter(s => s.departments?.some((d: any) => d.departmentId === dept.id));
   }, [sections, departments, filters.selectedDept]);
 
   return (

--- a/frontend/src/features/manager-portal/hooks/useManagerDashboardData.ts
+++ b/frontend/src/features/manager-portal/hooks/useManagerDashboardData.ts
@@ -3,6 +3,7 @@
 import { useEffect, useState, useCallback, useRef } from 'react';
 import { useRouter } from 'next/navigation';
 import { useAttendanceStream, AttendanceStreamPayload } from '@/features/attendance/hooks/useAttendanceStream';
+import { processAttendanceData } from '@/features/attendance/utils/attendance-logic';
 
 export interface LiveRecord {
     id: string;
@@ -137,35 +138,14 @@ export function useManagerDashboardData() {
             const todayPHTStr = phtStr(new Date());
             const weeklyAll: WeekDay[] = weekDates.map(({ day, date }) => {
                 const dateStr = phtStr(date);
+                if (dateStr > todayPHTStr) return { day, present: 0, late: 0, absent: 0 };
                 const dayAtts = weekAtts.filter(a => {
                     const recDate = a.date ? phtStr(new Date(a.date)) : '';
                     return recDate === dateStr;
                 });
-
-                const late = dayAtts.filter(a => a.checkInTime && a.lateMinutes > 0).length;
-                const onTime = dayAtts.filter(a => a.checkInTime && (a.lateMinutes ?? 0) === 0).length;
-                const totalCheckedIn = onTime + late;
-                const isDateHoliday = holidayDateSet.has(dateStr);
-                const eligibleCount = activeEmps.filter((e: any) => {
-                    if (!e.hireDate) return true;
-                    return phtStr(new Date(e.hireDate)) <= dateStr;
-                }).length;
-                const dayHoliday = holidayByDate.get(dateStr);
-                let absent: number;
-                if (dayHoliday) {
-                    const nonHolidayEmps = activeEmps.filter((e: any) => {
-                        if (e.hireDate && phtStr(new Date(e.hireDate)) > dateStr) return false;
-                        return !holidayApplies(dayHoliday, e.branchId);
-                    });
-                    const nonHolidayCheckedIn = dayAtts.filter(a => {
-                        const emp = a.employee || a.Employee || {};
-                        return !holidayApplies(dayHoliday, emp.branchId) && a.checkInTime;
-                    }).length;
-                    absent = dateStr <= todayPHTStr ? Math.max(0, nonHolidayEmps.length - nonHolidayCheckedIn) : 0;
-                } else {
-                    absent = dateStr <= todayPHTStr ? Math.max(0, eligibleCount - totalCheckedIn) : 0;
-                }
-                return { day, present: onTime, late, absent };
+                const dayHolidays = holidayByDate.get(dateStr) ? [holidayByDate.get(dateStr)!] : [];
+                const { stats: dayStats } = processAttendanceData(dayAtts, activeEmps, dateStr, dayHolidays);
+                return { day, present: dayStats.onTime, late: dayStats.late, absent: dayStats.absent };
             });
             const weekly = weeklyAll.filter(d => {
                 if (d.day !== 'Sun') return true;
@@ -173,16 +153,12 @@ export function useManagerDashboardData() {
             });
             setWeeklyData(weekly);
 
-            const todayLate = atts.filter(a => a.checkInTime && a.lateMinutes > 0).length;
-            const todayOnTime = atts.filter(a => a.checkInTime && !(a.lateMinutes > 0)).length;
-            const todayPresent = todayOnTime + todayLate;
-            setTotalPresent(todayOnTime);
-            setTotalLate(todayLate);
-            const todayEligible = activeEmps.filter((e: any) => {
-                if (!e.hireDate) return true;
-                return phtStr(new Date(e.hireDate)) <= todayPHTStr;
-            }).length;
-            const missingCount = Math.max(0, todayEligible - todayPresent);
+            // Use unified processAttendanceData for today's stats
+            const todayHolidayArr = todayHoliday ? [todayHoliday] : [];
+            const { stats: todayStats } = processAttendanceData(atts, activeEmps, todayStr, todayHolidayArr);
+            setTotalPresent(todayStats.onTime);
+            setTotalLate(todayStats.late);
+            setTotalAbsent(todayStats.absent);
             if (todayHoliday) {
                 const holidayAffected = activeEmps.filter((e: any) => {
                     if (e.hireDate && phtStr(new Date(e.hireDate)) > todayPHTStr) return false;
@@ -192,14 +168,8 @@ export function useManagerDashboardData() {
                     const emp = a.employee || a.Employee || {};
                     return holidayApplies(todayHoliday, emp.branchId) && a.checkInTime;
                 }).length;
-                const holidayMissing = Math.max(0, holidayAffected.length - holidayAffectedPresent);
-                const nonHolidayEligible = todayEligible - holidayAffected.length;
-                const nonHolidayPresent = todayPresent - holidayAffectedPresent;
-                const nonHolidayAbsent = Math.max(0, nonHolidayEligible - nonHolidayPresent);
-                setTotalAbsent(nonHolidayAbsent);
-                setTotalHoliday(holidayMissing);
+                setTotalHoliday(Math.max(0, holidayAffected.length - holidayAffectedPresent));
             } else {
-                setTotalAbsent(missingCount);
                 setTotalHoliday(0);
             }
 

--- a/frontend/src/features/organization/components/AddOrganizationDialog.tsx
+++ b/frontend/src/features/organization/components/AddOrganizationDialog.tsx
@@ -106,23 +106,7 @@ export function AddOrganizationDialog({
               </button>
             </div>
           </div>
-          {addType === 'section' && (
-            <div>
-              <label className="text-slate-400 text-[10px] uppercase tracking-widest font-bold">Department</label>
-              <select
-                className="mt-1.5 w-full px-3 py-2.5 rounded-xl border border-slate-200 bg-white text-sm font-medium text-slate-700 focus:ring-2 focus:ring-red-500/20 outline-none transition-all"
-                value={newSectionDeptId}
-                onChange={e => setNewSectionDeptId?.(e.target.value)}
-              >
-                <option value="">Select Department</option>
-                {departments.map(d => (
-                  <option key={d.id} value={d.id}>
-                    {d.name}
-                  </option>
-                ))}
-              </select>
-            </div>
-          )}
+          
           <div>
             <label className="text-slate-400 text-[10px] uppercase tracking-widest font-bold">
               {addType === 'department' ? 'Department Name' : addType === 'section' ? 'Section Name' : addType === 'branch' ? 'Branch Name' : 'Company Name'}
@@ -144,7 +128,8 @@ export function AddOrganizationDialog({
               <div className="space-y-1.5 max-h-40 overflow-y-auto">
                 {sections.map(s => {
                   const isChecked = newDeptSectionIds.includes(s.id)
-                  const ownerLabel = s.department?.name ? ` (${s.department.name})` : ''
+                  const associatedDepts = s.departments?.map((d: any) => d.department.name) || []
+                  const ownerLabel = associatedDepts.length > 0 ? ` (${associatedDepts.join(', ')})` : ''
                   return (
                     <label
                       key={s.id}

--- a/frontend/src/features/organization/components/EditDepartmentDialog.tsx
+++ b/frontend/src/features/organization/components/EditDepartmentDialog.tsx
@@ -71,9 +71,11 @@ export function EditDepartmentDialog({
               <div className="space-y-1.5 max-h-40 overflow-y-auto">
                 {sections.map(s => {
                   const isChecked = editSectionIds.includes(s.id)
-                  const isOwnedByOther = s.departmentId !== editingDept.id && isChecked === false
-                  const ownerLabel = s.department?.name && s.departmentId !== editingDept.id
-                    ? ` (${s.department.name})`
+                  const otherDepts = s.departments
+                    ?.map((d: any) => d.department.name)
+                    .filter((name: string) => name !== editingDept.name) || []
+                  const ownerLabel = otherDepts.length > 0
+                    ? ` (${otherDepts.join(', ')})`
                     : ''
                   return (
                     <label

--- a/frontend/src/features/organization/components/OrganizationPage.tsx
+++ b/frontend/src/features/organization/components/OrganizationPage.tsx
@@ -42,7 +42,7 @@ export default function OrganizationPage({ role }: OrganizationPageProps) {
   const openEditDept = (dept: Department) => {
     org.setEditingDept(dept)
     org.setEditName(dept.name)
-    const assignedIds = org.sections.filter(s => s.departmentId === dept.id).map(s => s.id)
+    const assignedIds = org.sections.filter(s => s.departments?.some(d => d.departmentId === dept.id)).map(s => s.id)
     org.setEditSectionIds(assignedIds)
     org.setEditError(null)
   }

--- a/frontend/src/features/organization/components/SectionCards.tsx
+++ b/frontend/src/features/organization/components/SectionCards.tsx
@@ -21,7 +21,7 @@ export function SectionCards({
         const color = getColor(index)
         const count = sectionCounts[section.name] || 0
         const initials = getInitials(section.name)
-        const deptName = section.department?.name || 'Unknown'
+        const deptName = section.departments?.map(d => d.department.name).join(', ') || 'Unassigned'
 
         return (
           <div

--- a/frontend/src/features/organization/hooks/useOrganization.ts
+++ b/frontend/src/features/organization/hooks/useOrganization.ts
@@ -187,18 +187,14 @@ export function useOrganization() {
         setNewName(''); setNewAddress(''); setIsAddOpen(false)
         showToast('success', 'Company Created', `${trimmed} has been added successfully`)
       } else if (addType === 'section') {
-        if (!newSectionDeptId) {
-          setAddError('Department is required for creating a section')
-          return
-        }
         const res = await fetch('/api/sections', {
           method: 'POST', headers: authHeaders(), credentials: 'include',
-          body: JSON.stringify({ name: trimmed, departmentId: parseInt(newSectionDeptId, 10) }),
+          body: JSON.stringify({ name: trimmed }),
         })
         const data = await res.json()
         if (!data.success) { setAddError(data.message || 'Failed to create'); return }
         setSections(prev => [...prev, data.section].sort((a, b) => a.name.localeCompare(b.name)))
-        setNewName(''); setNewSectionDeptId(''); setIsAddOpen(false)
+        setNewName(''); setIsAddOpen(false)
         showToast('success', 'Section Created', `${trimmed} has been added successfully`)
       } else {
         const endpoint = addType === 'department' ? '/api/departments' : '/api/branches'

--- a/frontend/src/features/organization/types.ts
+++ b/frontend/src/features/organization/types.ts
@@ -8,8 +8,7 @@ export interface Department {
 export interface Section {
   id: number
   name: string
-  departmentId: number
-  department?: { name: string }
+  departments?: { departmentId: number; department: { id: number; name: string } }[]
 }
 
 

--- a/frontend/src/features/reports/components/ReportFilters.tsx
+++ b/frontend/src/features/reports/components/ReportFilters.tsx
@@ -13,6 +13,9 @@ interface ReportFiltersProps {
   selectedDept: string;
   setSelectedDept: (v: string) => void;
   departments: string[];
+  selectedSection: string;
+  setSelectedSection: (v: string) => void;
+  sections: string[];
   searchTerm: string;
   setSearchTerm: (v: string) => void;
   onFilterChange: () => void; // Used to reset pagination when filters change
@@ -30,6 +33,9 @@ export const ReportFilters: React.FC<ReportFiltersProps> = ({
   selectedDept,
   setSelectedDept,
   departments,
+  selectedSection,
+  setSelectedSection,
+  sections,
   searchTerm,
   setSearchTerm,
   onFilterChange,
@@ -112,6 +118,26 @@ export const ReportFilters: React.FC<ReportFiltersProps> = ({
         </div>
         <div className="flex-1 min-w-0">
           <label className="text-slate-400 text-[10px] uppercase tracking-widest font-bold block mb-1.5">
+            Section
+          </label>
+          <select
+            value={selectedSection}
+            onChange={(e) => {
+              setSelectedSection(e.target.value);
+              onFilterChange();
+            }}
+            className="w-full px-3 py-2.5 rounded-xl border border-slate-200 bg-white text-sm font-medium text-slate-700 focus:ring-2 focus:ring-red-500/20 outline-none transition-all appearance-none cursor-pointer"
+          >
+            <option value="all">All Sections</option>
+            {sections.map((s) => (
+              <option key={s} value={s}>
+                {s}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div className="flex-1 min-w-0">
+          <label className="text-slate-400 text-[10px] uppercase tracking-widest font-bold block mb-1.5">
             Search
           </label>
           <div className="relative">
@@ -131,3 +157,4 @@ export const ReportFilters: React.FC<ReportFiltersProps> = ({
     </div>
   );
 };
+

--- a/frontend/src/features/reports/components/ReportsDashboard.tsx
+++ b/frontend/src/features/reports/components/ReportsDashboard.tsx
@@ -28,6 +28,7 @@ export function ReportsDashboard({ role = 'admin' }: { role?: 'admin' | 'hr' }) 
 
   const [searchTerm, setSearchTerm] = useState('');
   const [selectedDept, setSelectedDept] = useState('all');
+  const [selectedSection, setSelectedSection] = useState('all');
   const [selectedBranch, setSelectedBranch] = useState('all');
   const [currentPage, setCurrentPage] = useState(1);
   const rowsPerPage = 10;
@@ -52,6 +53,12 @@ export function ReportsDashboard({ role = 'admin' }: { role?: 'admin' | 'hr' }) 
   const departments = Array.from(
     new Set(reportData.map((e) => e.department).filter(Boolean))
   );
+  const sections = Array.from(
+    new Set(reportData
+      .filter((e) => selectedDept === 'all' || e.department === selectedDept)
+      .map((e) => e.section)
+      .filter((s) => s && s !== '—'))
+  );
   const branches = Array.from(
     new Set(reportData.map((e) => e.branch).filter(Boolean))
   );
@@ -70,9 +77,11 @@ export function ReportsDashboard({ role = 'admin' }: { role?: 'admin' | 'hr' }) 
 
     const matchesDept =
       selectedDept === 'all' || emp.department === selectedDept;
+    const matchesSection =
+      selectedSection === 'all' || emp.section === selectedSection;
     const matchesBranch =
       selectedBranch === 'all' || emp.branch === selectedBranch;
-    return matchesSearch && matchesDept && matchesBranch;
+    return matchesSearch && matchesDept && matchesSection && matchesBranch;
   });
 
   const { sortedData, sortKey, sortOrder, handleSort } = useTableSort<ReportRow>({
@@ -209,8 +218,11 @@ export function ReportsDashboard({ role = 'admin' }: { role?: 'admin' | 'hr' }) 
         setSelectedBranch={setSelectedBranch}
         branches={branches}
         selectedDept={selectedDept}
-        setSelectedDept={setSelectedDept}
+        setSelectedDept={(v) => { setSelectedDept(v); setSelectedSection('all'); }}
         departments={departments}
+        selectedSection={selectedSection}
+        setSelectedSection={setSelectedSection}
+        sections={sections}
         searchTerm={searchTerm}
         setSearchTerm={setSearchTerm}
         onFilterChange={handleFilterChange}

--- a/frontend/src/features/reports/hooks/useReportData.ts
+++ b/frontend/src/features/reports/hooks/useReportData.ts
@@ -91,6 +91,7 @@ export const useReportData = (startDate: string, endDate: string) => {
           employeeNumber?: string | null;
           zkId?: number | null;
           Department?: { name: string };
+          Section?: { name: string };
           Branch?: { name: string };
           employmentStatus: string;
           role: string;
@@ -132,6 +133,7 @@ export const useReportData = (startDate: string, endDate: string) => {
             employeeNumber: e.employeeNumber ?? null,
             zkId: e.zkId ?? null,
             department: e.Department?.name || '—',
+            section: e.Section?.name || '—',
             branch: e.Branch?.name || '—',
             totalDays,
             present: 0,

--- a/frontend/src/lib/fingerprintConstants.ts
+++ b/frontend/src/lib/fingerprintConstants.ts
@@ -13,6 +13,7 @@ export type DeviceSyncStatus = {
   enrolledAt?: string
   isActive: boolean
   syncEnabled: boolean
+  syncStatus?: 'synced' | 'partial' | 'not_synced'
 }
 
 export type FingerprintSlot = {

--- a/frontend/src/types/reports.ts
+++ b/frontend/src/types/reports.ts
@@ -48,6 +48,7 @@ export type ReportRow = {
   employeeNumber: string | null;
   zkId: number | null;
   department: string;
+  section: string;
   branch: string;
   totalDays: number;
   present: number;


### PR DESCRIPTION
## 📝 Description

This PR addresses multiple improvements across attendance, biometrics, and organization modules:

### Attendance — Multi-Status Filter Fix
- **Fixed** attendance filters not showing employees with multiple statuses (e.g., an employee who is "On Time" for arrival but "Undertime" for departure was hidden from both filters)
- Extracted shared attendance logic into a reusable [attendance-logic.ts](file:///c:/Users/OJT/new/bits/frontend/src/features/attendance/utils/attendance-logic.ts) utility module
- Unified Admin/HR and Manager dashboard filtering to use the same codebase, eliminating duplicated logic
- Removed redundant Undertime/Overtime status badges from the status column (dedicated UT/OT columns already display this)
- Extended attendance processor log query cutoff from 2 days → 30 days with pre-processing reconciliation for out-of-order log syncs

### Biometrics — Partial Sync Detection & Verification
- **Added** `partial` sync status detection — devices now show "Partially Synced" when only some fingerprints are synced
- Added post-enrollment verification step to confirm fingerprint template was successfully written to device
- Improved `hasFingerTemplate()` reliability by using `getFingerTemplate()` wrapper (avoids false positives from small firmware ACK packets)
- Optimized total enrolled finger count calculation using in-memory sets instead of device queries
- Added enrollment record cleanup when fingerprint push to target device fails

### Organization — Section-Department Many-to-Many Migration
- **BREAKING CHANGE:** Migrated Section-Department from one-to-many to many-to-many relationship via `SectionDepartment` join table
- Database migration preserves existing section-department links before dropping `departmentId`
- Updated all backend controllers (department, section, employee-export) to use join table queries
- Updated all frontend components and filters to use `departments[]` array with `.some()` pattern
- Section names are now globally unique instead of per-department

## 🔗 Related Issues
Addresses: Attendance filter bug report (employees with multiple statuses disappearing from filtered results)

## 🛠️ Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 🧹 Chore / Refactor (code cleanup, no functional changes)
- [ ] 📚 Documentation update

## 🧪 How Has This Been Tested?
- [x] **Unit Tests:** Comprehensive test suite with 69/69 assertions passed — covering on-time, late, undertime, grace period, OT, rest-day OT, multi-shift, night shift, double-punch guard, and out-of-order log sync scenarios
- [ ] **Integration Tests:** Verified data flow between services.
- [x] **Manual Testing:** Verified on local environment — attendance filters correctly show employees under all applicable statuses; partial sync badges display correctly; Section-Department M2M CRUD operations working

## 📸 Screenshots (if applicable)
<!-- Add screenshots of the partial sync badge, cleaned up status badges, etc. -->

## ✅ Checklist
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [ ] I have added/updated documentation related to these changes.
- [x] There are no hardcoded secrets or API keys included.

---
*By submitting this PR, I confirm that the code adheres to Avega Bros Integrated Shipping Corp. security and quality standards.*
